### PR TITLE
Add causal line-by-line logic derivation task

### DIFF
--- a/reasoning_core/tasks/logic_derivation.py
+++ b/reasoning_core/tasks/logic_derivation.py
@@ -1,0 +1,280 @@
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import dataclass
+from itertools import product
+
+from reasoning_core.template import Entry, Task, render_payload
+from reasoning_core.tasks.logic_depth import (
+    MultistepNLIConfig,
+    _rule_instances,
+    atom_text,
+    case_metadata,
+    derivation_rules,
+    generate_case,
+    indexed_premise,
+)
+
+
+@dataclass(frozen=True)
+class GroundStep:
+    atom: object
+    rule_line: int
+    parents: tuple
+
+
+@dataclass(frozen=True)
+class ProofDag:
+    steps: frozenset
+
+    @property
+    def size(self):
+        return len(self.steps)
+
+    def signature(self):
+        return tuple(sorted(
+            (
+                _atom_key(step.atom),
+                step.rule_line,
+                tuple(_atom_key(parent) for parent in step.parents),
+            )
+            for step in self.steps
+        ))
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    depth: int
+    size: int
+    traces: tuple
+    truncated: bool = False
+
+    @property
+    def unique(self):
+        return not self.truncated and len(self.traces) == 1
+
+    @property
+    def answer(self):
+        return self.traces[0] if self.unique else None
+
+
+def _atom_key(atom):
+    return atom.pred, atom.args, atom.sign
+
+
+def atom_code(atom):
+    sign = "" if atom.sign else "!"
+    return f"{sign}{atom.pred}({','.join(map(str, atom.args))})"
+
+
+def _merge_dags(dags, step):
+    by_atom = {}
+    for dag in dags:
+        for existing in dag.steps:
+            previous = by_atom.get(existing.atom)
+            if previous is not None and previous != existing:
+                return None
+            by_atom[existing.atom] = existing
+    previous = by_atom.get(step.atom)
+    if previous is not None and previous != step:
+        return None
+    by_atom[step.atom] = step
+    return ProofDag(frozenset(by_atom.values()))
+
+
+def _add_candidate(table, atom, depth, dag, max_candidates):
+    candidates = table[atom][depth]
+    signature = dag.signature()
+    if any(candidate.signature() == signature for candidate in candidates):
+        return False
+    candidates.append(dag)
+    candidates.sort(key=lambda candidate: (candidate.size, candidate.signature()))
+    truncated = len(candidates) > max_candidates
+    del candidates[max_candidates:]
+    return truncated
+
+
+def _ordered_steps(dag, target, facts):
+    by_atom = {step.atom: step for step in dag.steps}
+    ordered, seen = [], set()
+
+    def visit(atom):
+        if atom in facts or atom in seen:
+            return
+        step = by_atom[atom]
+        for parent in step.parents:
+            visit(parent)
+        seen.add(atom)
+        ordered.append(step)
+
+    visit(target)
+    return ordered
+
+
+def render_trace(dag, target, theory, source):
+    facts = set(theory.facts)
+    steps = _ordered_steps(dag, target, facts)
+    step_ids = {step.atom: i for i, step in enumerate(steps)}
+    lines = []
+    for step in steps:
+        supports = [
+            str(source[parent]) if parent in facts else f"@{step_ids[parent]}"
+            for parent in step.parents
+        ]
+        lines.append(
+            f"{step.rule_line}: {' '.join(supports) or '-'} => {atom_code(step.atom)}"
+        )
+    return "\n".join(lines)
+
+
+def canonical_trace(theory, res, source, target, max_depth=None, max_candidates=128):
+    """Return canonical minimum-depth, minimum-step proof traces for ``target``.
+
+    Candidates are proof DAGs, so a derived fact reused by several later steps is
+    emitted once. If the bounded search truncates, the result is marked ambiguous
+    and generation rejects it rather than claiming a false unique answer.
+    """
+    if max_candidates < 2:
+        raise ValueError("max_candidates must be at least 2")
+    if target not in res.derivations:
+        return None
+
+    target_depth = res.derivations[target].depth
+    max_depth = target_depth if max_depth is None else min(int(max_depth), target_depth)
+    if max_depth < target_depth:
+        return None
+
+    facts = set(theory.facts)
+    table = defaultdict(lambda: defaultdict(list))
+    for fact in theory.facts:
+        if fact in source:
+            table[fact][0].append(ProofDag(frozenset()))
+
+    instances = [
+        (source[rule], head, parents)
+        for rule in theory.rules
+        if rule in source
+        for head, parents in _rule_instances(rule, res.closure)
+        if head not in facts
+    ]
+
+    truncated = False
+    for depth in range(1, max_depth + 1):
+        for rule_line, head, parents in instances:
+            choices = []
+            for parent in parents:
+                options = [
+                    (parent_depth, dag)
+                    for parent_depth, dags in table[parent].items()
+                    if parent_depth < depth
+                    for dag in dags
+                ]
+                if not options:
+                    break
+                choices.append(options)
+            else:
+                combinations = product(*choices) if choices else [()]
+                for combination in combinations:
+                    parent_depths = [item[0] for item in combination]
+                    if 1 + max(parent_depths, default=0) != depth:
+                        continue
+                    step = GroundStep(
+                        head,
+                        rule_line,
+                        tuple(parents),
+                    )
+                    dag = _merge_dags([item[1] for item in combination], step)
+                    if dag is not None:
+                        truncated |= _add_candidate(
+                            table, head, depth, dag, max_candidates
+                        )
+
+    candidates = table[target].get(target_depth, ())
+    if not candidates:
+        return None
+    size = min(candidate.size for candidate in candidates)
+    traces = tuple(sorted({
+        render_trace(candidate, target, theory, source)
+        for candidate in candidates
+        if candidate.size == size
+    }))
+    return TraceResult(target_depth, size, traces, truncated)
+
+
+def normalize_trace(text):
+    return "\n".join(
+        "".join(line.split())
+        for line in str(text).strip().splitlines()
+        if line.strip()
+    )
+
+
+class LogicDerivation(Task):
+    summary = "Produce a canonical forward proof trace for a logical target."
+
+    def __init__(self, config=None):
+        super().__init__(config=config or MultistepNLIConfig())
+        self.balancing_key_ratio = 1 / 3
+        self._case_state = {}
+
+    def generate_entry(self):
+        for _ in range(300):
+            trial_state = deepcopy(self._case_state)
+            case, key = generate_case(
+                self.config,
+                ("entailment", "contradiction"),
+                trial_state,
+            )
+            if not case:
+                continue
+
+            trace = canonical_trace(
+                case.theory,
+                case.res,
+                case.source,
+                case.target,
+                max_depth=case.derivation.depth,
+            )
+            if trace is None or not trace.unique:
+                continue
+
+            self._case_state = trial_state
+            rules = derivation_rules(case.target, case.res.derivations)
+            meta = case_metadata(case, key)
+            meta.target = atom_text(case.target, case.theory.domain_pack) + "."
+            meta.proof_depth = trace.depth
+            meta.proof_steps = trace.size
+            meta.optimal_trace_count = len(trace.traces)
+            meta.uses_binary = any(
+                len(atom.args) == 2 for atom in case.support_atoms | {case.target}
+            )
+            meta.uses_signed = any(not rule.head.sign for rule in rules)
+            meta.uses_composition = any("composition" in rule.shape for rule in rules)
+            meta.payload = {
+                "premise": indexed_premise(case.lines),
+                "target": meta.target,
+            }
+            return Entry(meta, trace.answer)
+
+        raise RuntimeError("could not generate a unique logic_derivation example")
+
+    def render_prompt(self, meta):
+        return (
+            f"{render_payload(meta.payload)}\n\n"
+            "Give the proof, one step per line: `rule: supports => conclusion`. "
+            "Use premise lines for facts, `@i` for earlier proof lines, and keep "
+            "supports in rule-condition order. Write conclusions as `p(x)` or `!p(x)`."
+        )
+
+    def score_answer(self, answer, entry):
+        return float(normalize_trace(answer) == normalize_trace(entry.answer))
+
+    def balancing_key(self, problem):
+        meta = problem.metadata
+        return (
+            meta.domain_pack,
+            min(meta.proof_depth, 4),
+            min(meta.proof_steps, 6),
+            meta.uses_binary,
+            meta.uses_signed,
+            meta.uses_composition,
+        )

--- a/tests/test_logic_derivation.py
+++ b/tests/test_logic_derivation.py
@@ -1,0 +1,119 @@
+from reasoning_core import get_task, list_tasks, score_answer
+from reasoning_core.tasks.logic_depth import Atom, PredSig, Rule, Theory, chase, render
+from reasoning_core.tasks.logic_derivation import atom_code, canonical_trace
+
+
+def unary_theory(facts, rules):
+    preds = {atom.pred for atom in facts}
+    preds |= {
+        atom.pred
+        for rule in rules
+        for atom in (*rule.body, rule.head)
+        if isinstance(atom, Atom)
+    }
+    return Theory(
+        facts=facts,
+        rules=rules,
+        denials=[],
+        pred_sigs={p: PredSig(p, ("person",)) for p in preds},
+        entities={"person": ("alice",)},
+    )
+
+
+def test_canonical_trace_is_forward_and_uses_step_references():
+    x = ("alice",)
+    a, b, c, target = [Atom(p, x) for p in ("a", "b", "c", "target")]
+    theory = unary_theory(
+        [a, b],
+        [Rule((a,), c), Rule((c, b), target)],
+    )
+    res = chase(theory)
+    _, source, _ = render(theory)
+    trace = canonical_trace(theory, res, source, target)
+
+    assert trace.unique
+    assert trace.depth == 2
+    assert trace.size == 2
+    assert trace.answer == (
+        "2: 0 => c(alice)\n"
+        "3: @0 1 => target(alice)"
+    )
+
+
+def test_canonical_trace_optimizes_proof_dag_steps_with_sharing():
+    x = ("alice",)
+    a, b, shared, left, right, u, v, target = [
+        Atom(p, x)
+        for p in ("a", "b", "shared", "left", "right", "u", "v", "target")
+    ]
+    theory = unary_theory(
+        [a, b],
+        [
+            Rule((a,), shared),
+            Rule((shared,), left),
+            Rule((shared,), right),
+            Rule((a,), u),
+            Rule((u,), left),
+            Rule((b,), v),
+            Rule((v,), right),
+            Rule((left, right), target),
+        ],
+    )
+    res = chase(theory)
+    _, source, _ = render(theory)
+    trace = canonical_trace(theory, res, source, target)
+
+    assert trace.unique
+    assert trace.depth == 3
+    assert trace.size == 4
+    assert trace.answer == (
+        "2: 0 => shared(alice)\n"
+        "3: @0 => left(alice)\n"
+        "4: @0 => right(alice)\n"
+        "9: @1 @2 => target(alice)"
+    )
+
+
+def test_canonical_trace_rejects_equal_optimal_derivations():
+    x = ("alice",)
+    a, b, target = [Atom(p, x) for p in ("a", "b", "target")]
+    theory = unary_theory(
+        [a, b],
+        [Rule((a,), target), Rule((b,), target)],
+    )
+    res = chase(theory)
+    _, source, _ = render(theory)
+    trace = canonical_trace(theory, res, source, target)
+
+    assert not trace.unique
+    assert trace.answer is None
+    assert set(trace.traces) == {
+        "2: 0 => target(alice)",
+        "3: 1 => target(alice)",
+    }
+
+
+def test_negative_atoms_use_compact_bang_notation():
+    assert atom_code(Atom("flagged", ("alice",), False)) == "!flagged(alice)"
+
+
+def test_logic_derivation_registers_generates_and_scores():
+    assert "logic_derivation" in list_tasks()
+    task = get_task("logic_derivation")
+    ex = task.generate_example(max_tokens=0)
+
+    assert ex.answer
+    assert "=>" in ex.answer
+    assert ex.metadata.target
+    assert ex.metadata.proof_depth >= 2
+    assert ex.metadata.proof_steps >= ex.metadata.proof_depth
+    assert ex.metadata.optimal_trace_count == 1
+    assert score_answer(ex.answer, ex) == 1
+
+    spaced = ex.answer.replace(":", " : ").replace("=>", " => ")
+    assert task.score_answer(spaced, ex) == 1
+    assert task.score_answer(ex.answer + "\n0: 0 => bogus(alice)", ex) == 0
+
+    for i, line in enumerate(ex.answer.splitlines()):
+        refs = [token for token in line.split() if token.startswith("@")]
+        assert all(int(ref[1:]) < i for ref in refs)


### PR DESCRIPTION
## What changed
- add a `logic_derivation` task that reuses `logic_depth` generation, rendering, focusing, domain packs, metadata, balancing, and difficulty controls
- replace nested proof terms with canonical forward traces such as:

```text
3: 0 1 => careful(alice)
4: @0 => approved(alice)
```

- optimize proofs by minimum derivation depth, then minimum number of derived DAG steps
- emit shared intermediate facts once and reference them causally with `@i`
- reject examples with multiple optimal traces or any truncated proof search
- commit generation balancing state only for accepted examples

## Canonicalization
- proof steps are emitted in deterministic postorder, so every `@i` points backward
- supports follow rule-condition order
- facts use displayed premise indexes
- conclusions use `p(x)` and `!p(x)`
- whitespace is ignored by scoring, but line ordering is exact

## Tests
- causal forward ordering and step references
- DAG sharing beats an equal-depth unshared proof
- equal optimal derivations are rejected
- compact negative-atom rendering
- task registration, generation metadata, scoring, and backward-only references

## Validation
- isolated executable tests passed for forward traces, DAG sharing, and ambiguity detection
- full repository tests were not run because this environment cannot resolve GitHub for a checkout

This supersedes the nested-term design in #43 while leaving that draft PR untouched.