### PR TITLE
Add UltraMix procedural edge generators

### DIFF
--- a/reasoning_core/tasks/generated/response_contracts.py
+++ b/reasoning_core/tasks/generated/response_contracts.py
@@ -1,0 +1,247 @@
+import json
+import random
+import string
+from dataclasses import dataclass
+
+from reasoning_core.template import Entry, Config, Task, edict, stochastic_rounding as sround
+from ._base import GeneratedMixin
+
+
+def _json(obj):
+    return json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
+
+
+def _json_score(answer, entry):
+    try:
+        predicted = json.loads(str(answer).strip())
+        reference = json.loads(entry["answer"] if isinstance(entry, dict) else entry.answer)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 0.0
+    return float(predicted == reference)
+
+
+@dataclass
+class SchemaBoundQueryConfig(Config):
+    n_rows: int = 6
+    n_groups: int = 3
+    magnitude: int = 9
+    max_attempts: int = 100
+
+    def apply_difficulty(self, level):
+        self.n_rows = sround(self.n_rows + 1.3 * level)
+        self.n_groups = sround(self.n_groups + 0.25 * level)
+        self.magnitude = sround(self.magnitude + 1.1 * level)
+        self.max_attempts = sround(self.max_attempts + 10 * level)
+
+
+class SchemaBoundQuery(GeneratedMixin, Task):
+    summary = "Execute a record query while satisfying a sampled exact nested JSON schema."
+    config_cls = SchemaBoundQueryConfig
+
+    def generate_entry(self):
+        cfg = self.config
+        groups = list(string.ascii_uppercase[:max(2, min(cfg.n_groups, 8))])
+        for _ in range(cfg.max_attempts):
+            rows = [
+                {"id": f"R{i+1}", "group": random.choice(groups), "value": random.randint(-cfg.magnitude, cfg.magnitude)}
+                for i in range(cfg.n_rows)
+            ]
+            group = random.choice(groups)
+            threshold = random.randint(-cfg.magnitude, cfg.magnitude)
+            selected = [r for r in rows if r["group"] == group and r["value"] >= threshold]
+            if not selected or len(selected) == len(rows):
+                continue
+            schema = random.choice(("flat", "nested", "records"))
+            ids = [r["id"] for r in selected]
+            total = sum(r["value"] for r in selected)
+            if schema == "flat":
+                answer = {"ids": ids, "count": len(ids), "total": total}
+            elif schema == "nested":
+                answer = {"selection": {"ids": ids, "count": len(ids)}, "aggregate": {"total": total}}
+            else:
+                answer = {"matches": [{"id": r["id"], "value": r["value"]} for r in selected], "total": total}
+            return Entry(metadata=edict(rows=rows, group=group, threshold=threshold, schema=schema), answer=_json(answer))
+        raise RuntimeError("Failed to generate a nontrivial schema-bound query")
+
+    def render_prompt(self, m):
+        rows = "\n".join(f"{r['id']}: group={r['group']}, value={r['value']}" for r in m.rows)
+        schemas = {
+            "flat": '{"ids":[string,...],"count":integer,"total":integer}',
+            "nested": '{"selection":{"ids":[string,...],"count":integer},"aggregate":{"total":integer}}',
+            "records": '{"matches":[{"id":string,"value":integer},...],"total":integer}',
+        }
+        return (
+            f"Records:\n{rows}\n\nSelect records with group={m.group} and value >= {m.threshold}, preserving input order.\n"
+            f"Answer as JSON matching exactly this schema, with no extra keys or prose:\n{schemas[m.schema]}"
+        )
+
+    def score_answer(self, answer, entry):
+        return _json_score(answer, entry)
+
+    def balancing_key(self, problem):
+        return problem.metadata.schema
+
+
+@dataclass
+class ConditionalResponseContractConfig(Config):
+    n_records: int = 6
+    n_rules: int = 2
+    magnitude: int = 12
+    max_attempts: int = 100
+
+    def apply_difficulty(self, level):
+        self.n_records = sround(self.n_records + 0.9 * level)
+        self.n_rules = min(4, sround(self.n_rules + 0.35 * level))
+        self.magnitude = sround(self.magnitude + 1.4 * level)
+        self.max_attempts = sround(self.max_attempts + 10 * level)
+
+
+def _condition(rule, winner):
+    kind, arg, _, _ = rule
+    if kind == "even":
+        return winner["score"] % 2 == 0
+    if kind == "high":
+        return winner["score"] >= arg
+    if kind == "group":
+        return winner["group"] == arg
+    if kind == "flag":
+        return winner["flag"] == "yes"
+    raise ValueError(kind)
+
+
+def _apply_rule(text, rule):
+    _, _, action, token = rule
+    if action == "append":
+        return f"{text} {token}"
+    if action == "prepend":
+        return f"{token} {text}"
+    if action == "wrap":
+        left, right = token
+        return f"{left}{text}{right}"
+    raise ValueError(action)
+
+
+def _rule_text(rule):
+    kind, arg, action, token = rule
+    cond = {
+        "even": "the winner's score is even",
+        "high": f"the winner's score is at least {arg}",
+        "group": f"the winner's group is {arg}",
+        "flag": "the winner's flag is yes",
+    }[kind]
+    effect = {
+        "append": f"append token {token}",
+        "prepend": f"prepend token {token}",
+        "wrap": f"wrap the entire current answer in {token[0]} and {token[1]}",
+    }[action]
+    return f"If {cond}, {effect}; otherwise do nothing."
+
+
+class ConditionalResponseContract(GeneratedMixin, Task):
+    summary = "Solve a selection problem and execute output transformations whose activation depends on the semantic result."
+    config_cls = ConditionalResponseContractConfig
+
+    def generate_entry(self):
+        cfg = self.config
+        groups = ("A", "B", "C")
+        actions = (("append", "EVEN"), ("prepend", "GROUP"), ("append", "HIGH"), ("wrap", ("[", "]")))
+        for _ in range(cfg.max_attempts):
+            rows = [
+                {"id": f"R{i+1}", "score": random.randint(0, cfg.magnitude), "eligible": random.choice(("yes", "yes", "no")),
+                 "group": random.choice(groups), "flag": random.choice(("yes", "no"))}
+                for i in range(cfg.n_records)
+            ]
+            eligible = [r for r in rows if r["eligible"] == "yes"]
+            if not eligible:
+                continue
+            winner = min(eligible, key=lambda r: (-r["score"], r["id"]))
+            cutoff = random.randint(1, cfg.magnitude)
+            catalog = [
+                ("even", None, *actions[0]),
+                ("group", random.choice(groups), *actions[1]),
+                ("high", cutoff, *actions[2]),
+                ("flag", None, *actions[3]),
+            ]
+            rules = random.sample(catalog, min(cfg.n_rules, len(catalog)))
+            states = [_condition(r, winner) for r in rules]
+            if len(rules) > 1 and (all(states) or not any(states)):
+                continue
+            answer = winner["id"]
+            for active, rule in zip(states, rules):
+                if active:
+                    answer = _apply_rule(answer, rule)
+            return Entry(metadata=edict(rows=rows, rules=rules, winner=winner["id"], states=states), answer=answer)
+        raise RuntimeError("Failed to generate a mixed conditional-contract instance")
+
+    def render_prompt(self, m):
+        rows = "\n".join(
+            f"{r['id']}: score={r['score']}, eligible={r['eligible']}, group={r['group']}, flag={r['flag']}" for r in m.rows
+        )
+        rules = "\n".join(f"{i}. {_rule_text(r)}" for i, r in enumerate(m.rules, 1))
+        return (
+            f"Records:\n{rows}\n\nChoose the eligible record with the largest score; break ties by lexicographically smallest ID. "
+            "Start the answer as that ID. Then apply these rules in order to the current answer:\n"
+            f"{rules}\nThe answer is the final transformed string and nothing else."
+        )
+
+    def score_answer(self, answer, entry):
+        reference = entry["answer"] if isinstance(entry, dict) else entry.answer
+        return float(str(answer).strip() == str(reference).strip())
+
+    def balancing_key(self, problem):
+        return tuple(problem.metadata.states)
+
+
+@dataclass
+class ProtectedSpanTransformationConfig(Config):
+    n_items: int = 6
+    magnitude: int = 8
+    max_attempts: int = 100
+
+    def apply_difficulty(self, level):
+        self.n_items = sround(self.n_items + 1.1 * level)
+        self.magnitude = sround(self.magnitude + 1.3 * level)
+        self.max_attempts = sround(self.max_attempts + 10 * level)
+
+
+def _protected_token(i):
+    a, b = random.sample(string.ascii_letters, 2)
+    return f"<{a}{i:02d}:{b}-{random.randint(0, 9)}>"
+
+
+class ProtectedSpanTransformation(GeneratedMixin, Task):
+    summary = "Select and transform records while preserving opaque protected spans byte-for-byte."
+    config_cls = ProtectedSpanTransformationConfig
+
+    def generate_entry(self):
+        cfg = self.config
+        for _ in range(cfg.max_attempts):
+            items = [{"token": _protected_token(i), "value": random.randint(-cfg.magnitude, cfg.magnitude)} for i in range(cfg.n_items)]
+            a = random.choice((-3, -2, 2, 3))
+            b = random.randint(-cfg.magnitude, cfg.magnitude)
+            parity = random.choice((0, 1))
+            selected = [dict(x, result=a * x["value"] + b) for x in items if abs(x["value"]) % 2 == parity]
+            if not selected or len(selected) == len(items):
+                continue
+            selected.sort(key=lambda x: (x["result"], x["token"]))
+            answer = "\n".join(f"{x['token']}={x['result']}" for x in selected)
+            return Entry(metadata=edict(records=items, a=a, b=b, parity=parity), answer=answer)
+        raise RuntimeError("Failed to generate a nontrivial protected-span transformation")
+
+    def render_prompt(self, m):
+        items = "\n".join(f"{x['token']} value={x['value']}" for x in m.records)
+        parity = "even" if m.parity == 0 else "odd"
+        sign = "+" if m.b >= 0 else "-"
+        return (
+            f"Items:\n{items}\n\nKeep exactly the items whose absolute original value is {parity}. "
+            f"For each kept item compute {m.a}*value {sign} {abs(m.b)}. Sort kept items by the computed value ascending, then by protected span. "
+            "Each answer line is PROTECTED_SPAN=COMPUTED_VALUE. Copy every protected span exactly, including case and punctuation."
+        )
+
+    def score_answer(self, answer, entry):
+        reference = entry["answer"] if isinstance(entry, dict) else entry.answer
+        norm = lambda x: "\n".join(line.strip() for line in str(x).strip().splitlines())
+        return float(norm(answer) == norm(reference))
+
+    def balancing_key(self, problem):
+        return "even" if problem.metadata.parity == 0 else "odd"

--- a/reasoning_core/tasks/generated/structured_extraction.py
+++ b/reasoning_core/tasks/generated/structured_extraction.py
@@ -1,0 +1,182 @@
+import json
+import random
+from dataclasses import dataclass
+
+from reasoning_core.template import Entry, Config, Task, edict, stochastic_rounding as sround
+from ._base import GeneratedMixin
+
+
+_NAMES = ("Ari", "Bela", "Cleo", "Dara", "Enzo", "Fara", "Gio", "Hana", "Ivo", "Juna", "Kian", "Lumi")
+_RELATIONS = {
+    "supports": (
+        ("{s} supports {o}.", "{s} does not support {o}."),
+        ("{o} receives support from {s}.", "{o} does not receive support from {s}."),
+    ),
+    "manages": (
+        ("{s} manages {o}.", "{s} does not manage {o}."),
+        ("{o} reports to {s}.", "{o} does not report to {s}."),
+    ),
+    "precedes": (
+        ("{s} precedes {o}.", "{s} does not precede {o}."),
+        ("{o} follows {s}.", "{o} does not follow {s}."),
+    ),
+    "visits": (
+        ("{s} visits {o}.", "{s} does not visit {o}."),
+        ("{o} is visited by {s}.", "{o} is not visited by {s}."),
+    ),
+}
+_TARGET_RELATIONS = ("supports", "manages", "precedes")
+_PROPERTIES = ("calm", "careful", "direct", "eager", "focused", "gentle", "patient", "quiet", "steady", "vivid")
+
+
+def _json_score(answer, entry):
+    try:
+        predicted = json.loads(str(answer).strip())
+        reference = json.loads(entry["answer"] if isinstance(entry, dict) else entry.answer)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return 0.0
+    return float(predicted == reference)
+
+
+def _json(obj):
+    return json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
+
+
+@dataclass
+class TypedRelationExtractionConfig(Config):
+    n_entities: int = 5
+    n_sentences: int = 7
+    max_attempts: int = 100
+
+    def apply_difficulty(self, level):
+        self.n_entities = sround(self.n_entities + 0.5 * level)
+        self.n_sentences = sround(self.n_sentences + 1.4 * level)
+        self.max_attempts = sround(self.max_attempts + 10 * level)
+
+
+class TypedRelationExtraction(GeneratedMixin, Task):
+    summary = "Extract the complete set of typed relations with sentence provenance while ignoring negated and irrelevant statements."
+    config_cls = TypedRelationExtractionConfig
+
+    def generate_entry(self):
+        cfg = self.config
+        names = random.sample(_NAMES, min(cfg.n_entities, len(_NAMES)))
+        for _ in range(cfg.max_attempts):
+            sentences, records, seen = [], [], set()
+            for i in range(1, cfg.n_sentences + 1):
+                relation = random.choice(tuple(_RELATIONS))
+                s, o = random.sample(names, 2)
+                key = relation, s, o
+                if key in seen:
+                    continue
+                seen.add(key)
+                positive = random.random() >= 0.28
+                pattern = random.choice(_RELATIONS[relation])[0 if positive else 1]
+                sentences.append(pattern.format(s=s, o=o))
+                if positive and relation in _TARGET_RELATIONS:
+                    records.append({"relation": relation, "source": s, "target": o, "evidence": len(sentences)})
+            if len(sentences) < max(4, cfg.n_sentences // 2) or len(records) < 2 or len(records) == len(sentences):
+                continue
+            metadata = edict(sentences=sentences, records=records)
+            return Entry(metadata=metadata, answer=_json(records))
+        raise RuntimeError("Failed to generate a varied relation-extraction instance")
+
+    def render_prompt(self, m):
+        text = "\n".join(f"{i}. {s}" for i, s in enumerate(m.sentences, 1))
+        return (
+            f"Statements:\n{text}\n\n"
+            "Extract every affirmative supports, manages, and precedes relation. Interpret reversed wording semantically. "
+            "Ignore negated statements and all other relation types. The answer is a JSON array in evidence-sentence order. "
+            "Each object has exactly the keys relation, source, target, evidence, where evidence is the sentence number."
+        )
+
+    def score_answer(self, answer, entry):
+        return _json_score(answer, entry)
+
+    def balancing_key(self, problem):
+        return min(5, len(problem.metadata.records))
+
+
+@dataclass
+class EvidenceSufficiencyConfig(Config):
+    n_entities: int = 4
+    n_properties: int = 6
+    n_evidence: int = 8
+    claim_atoms: int = 2
+
+    def apply_difficulty(self, level):
+        self.n_entities = sround(self.n_entities + 0.35 * level)
+        self.n_properties = sround(self.n_properties + 0.5 * level)
+        self.n_evidence = sround(self.n_evidence + 1.3 * level)
+        self.claim_atoms = sround(self.claim_atoms + 0.3 * level)
+
+
+class EvidenceSufficiency(GeneratedMixin, Task):
+    summary = "Distinguish sufficient, contradictory, and merely related evidence and identify the exact witness sentences."
+    config_cls = EvidenceSufficiencyConfig
+
+    def generate_entry(self):
+        cfg = self.config
+        names = random.sample(_NAMES, min(cfg.n_entities, len(_NAMES)))
+        properties = random.sample(_PROPERTIES, min(cfg.n_properties, len(_PROPERTIES)))
+        target = random.choice(names)
+        claim = random.sample(properties, min(cfg.claim_atoms, len(properties)))
+        verdict = random.choice(("supported", "contradicted", "insufficient"))
+        facts = []
+
+        if verdict == "supported":
+            facts.extend((target, p, True) for p in claim)
+        elif verdict == "contradicted":
+            neg = random.choice(claim)
+            facts.append((target, neg, False))
+            facts.extend((target, p, True) for p in claim if p != neg and random.random() < 0.6)
+        else:
+            shown = random.sample(claim, random.randrange(1, len(claim))) if len(claim) > 1 else []
+            facts.extend((target, p, True) for p in shown)
+
+        forbidden = {(target, p) for p in claim}
+        pool = [(n, p, sign) for n in names for p in properties for sign in (True, False)
+                if (n, p) not in forbidden]
+        random.shuffle(pool)
+        for item in pool:
+            if len(facts) >= cfg.n_evidence:
+                break
+            if item[:2] not in {(n, p) for n, p, _ in facts}:
+                facts.append(item)
+        random.shuffle(facts)
+
+        sentences, positive_ids, negative_ids = [], {}, {}
+        for i, (name, prop, sign) in enumerate(facts, 1):
+            if sign:
+                text = random.choice((f"{name} is {prop}.", f"The evidence states that {name} is {prop}."))
+                positive_ids[(name, prop)] = i
+            else:
+                text = random.choice((f"{name} is not {prop}.", f"The evidence states that {name} is not {prop}."))
+                negative_ids[(name, prop)] = i
+            sentences.append(text)
+
+        if verdict == "supported":
+            witness = sorted(positive_ids[(target, p)] for p in claim)
+        elif verdict == "contradicted":
+            witness = [min(negative_ids[(target, p)] for p in claim if (target, p) in negative_ids)]
+        else:
+            witness = []
+        answer = {"verdict": verdict, "evidence": witness}
+        return Entry(metadata=edict(sentences=sentences, target=target, claim=claim, verdict=verdict), answer=_json(answer))
+
+    def render_prompt(self, m):
+        evidence = "\n".join(f"{i}. {s}" for i, s in enumerate(m.sentences, 1))
+        claim = " and ".join(f"{m.target} is {p}" for p in m.claim)
+        return (
+            f"Evidence:\n{evidence}\n\nClaim: {claim}.\n"
+            "Use only the supplied evidence. The verdict is supported iff every conjunct is explicitly affirmed; "
+            "contradicted iff at least one conjunct is explicitly negated; otherwise it is insufficient. "
+            "The answer is JSON with exactly keys verdict and evidence. For supported, evidence lists every sentence needed for the conjuncts; "
+            "for contradicted, it lists the single smallest-numbered contradicting sentence; for insufficient, it is []."
+        )
+
+    def score_answer(self, answer, entry):
+        return _json_score(answer, entry)
+
+    def balancing_key(self, problem):
+        return problem.metadata.verdict

--- a/tests/test_generated_ultramix.py
+++ b/tests/test_generated_ultramix.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from reasoning_core.tasks.generated.response_contracts import (
+    ConditionalResponseContract,
+    ProtectedSpanTransformation,
+    SchemaBoundQuery,
+)
+from reasoning_core.tasks.generated.structured_extraction import EvidenceSufficiency, TypedRelationExtraction
+
+
+TASKS = [
+    TypedRelationExtraction,
+    EvidenceSufficiency,
+    SchemaBoundQuery,
+    ConditionalResponseContract,
+    ProtectedSpanTransformation,
+]
+
+
+@pytest.mark.parametrize("task_cls", TASKS)
+def test_generated_ultramix_reference_and_wrong_answer(task_cls):
+    task = task_cls()
+    for _ in range(8):
+        entry = task.generate_example()
+        assert task.score_answer(entry.answer, entry) == 1
+        assert task.score_answer("__definitely_wrong__", entry) < 1
+
+
+@pytest.mark.parametrize("task_cls", [TypedRelationExtraction, EvidenceSufficiency, SchemaBoundQuery])
+def test_generated_ultramix_json_scoring_is_key_order_insensitive(task_cls):
+    task = task_cls()
+    entry = task.generate_example()
+    pretty = json.dumps(json.loads(entry.answer), indent=2, sort_keys=True)
+    assert task.score_answer(pretty, entry) == 1
+
+
+def test_generated_ultramix_difficulty_changes_structure():
+    for task_cls, field in [
+        (TypedRelationExtraction, "n_sentences"),
+        (EvidenceSufficiency, "n_evidence"),
+        (SchemaBoundQuery, "n_rows"),
+        (ConditionalResponseContract, "n_records"),
+        (ProtectedSpanTransformation, "n_items"),
+    ]:
+        task = task_cls()
+        base = getattr(task.config, field)
+        task.config.set_level(4)
+        assert getattr(task.config, field) > base


### PR DESCRIPTION
## What changed

Adds five mechanically verifiable generated tasks motivated by proceduralizable UltraMix preference distinctions:

- `typed_relation_extraction`: complete typed relation extraction with sentence provenance, negation, reversed wording, and irrelevant-relation distractors
- `evidence_sufficiency`: supported / contradicted / insufficient grounding with exact witness sentence selection
- `schema_bound_query`: semantic record filtering and aggregation under sampled exact JSON schemas
- `conditional_response_contract`: semantic selection followed by ordered, result-dependent output transformations
- `protected_span_transformation`: filtering and arithmetic transformation while preserving opaque spans byte-for-byte

Also adds focused tests for reference scoring, wrong-answer rejection, JSON key-order tolerance, and difficulty scaling.

## Why

These implement the strongest procedural whitespace identified in UltraMix beyond the existing Reasoning Core gallery: structured extraction/grounding plus compositional instruction contracts. Every instance is generated from controlled latent state and uses a mechanical oracle. Format-only behavior stays attached to semantic work rather than becoming standalone casing/counting drills.

## Validation

- `py_compile` passes for both task modules and the test module.
- A local compatibility harness generated and scored 300 examples per task at levels 0, 2, and 5. Every reference answer scored 1 and a fixed wrong answer scored below 1.
- The stress pass caught and fixed an `EasyDict`/`dict.items` metadata-name collision before publishing.
- Full repository pytest was not available in this runtime because the repository is not locally mounted; `tests/test_generated_ultramix.py` is included for normal local/CI validation.

## Scope

Only two new generated-task modules and one focused test file are changed. `GALLERY.md` is not regenerated because its build requires the repository runtime/cache machinery.