### PR TITLE
add spatial folding, matrix induction, and rule switching tasks

### DIFF
--- a/reasoning_core/tasks/generated/matrix_induction.py
+++ b/reasoning_core/tasks/generated/matrix_induction.py
@@ -152,7 +152,7 @@ class MatrixInduction(GeneratedMixin, Task):
     def score_answer(self, answer, entry):
         def parse(text):
             out = {}
-            for name in entry.metadata.attributes:
+            for name in entry.metadata["attributes"]:
                 m = re.search(rf"\b{name}\s*=\s*([A-Za-z0-9_-]+)", str(text), re.I)
                 if not m:
                     return None

--- a/reasoning_core/tasks/generated/spatial_folding.py
+++ b/reasoning_core/tasks/generated/spatial_folding.py
@@ -111,7 +111,7 @@ class SpatialFolding(GeneratedMixin, Task):
     def score_answer(self, answer, entry):
         pairs = re.findall(r"(\d+)\s*,\s*(\d+)", str(answer))
         parsed = [(int(r), int(c)) for r, c in pairs]
-        gold = [(r + 1, c + 1) for r, c in entry.metadata.holes]
+        gold = [(r + 1, c + 1) for r, c in entry.metadata["holes"]]
         return float(len(parsed) == len(gold) and set(parsed) == set(gold))
 
     def balancing_key(self, problem):


### PR DESCRIPTION
## Summary

Adds three procedural tasks under `reasoning_core/tasks/generated/` targeting cognitive factors not cleanly isolated by the existing gallery:

- `spatial_folding`: fold/unfold spatial transformation with canonical row-major hole coordinates.
- `matrix_induction`: multi-attribute 3x3 rule induction over an explicit finite rule family. Instances are accepted only when every rule consistent with the visible matrix agrees on the missing value, so answer uniqueness does not depend on uniqueness of the latent generating rule.
- `rule_switching`: symbolic state tracking under changing opcode semantics. Generated traces certify a minimum dependency depth and require the same opcode to have different meanings across modes along the queried value's actual backward lineage.

Difficulty scales folds/punches, active matrix attributes/harder rule positions, and register width/update depth/mode count respectively.

## Validation

Validated against the real repository environment with `task.validate(n_samples=20)` for each task at every level 0 through 5. All 18 task/level combinations passed, including the serialize/deserialize scoring round trip.

Additional generator stress checks used 100 instances per level to verify:

- spatial fold/unfold preimages against forward folding,
- matrix missing-value uniqueness by independent version-space enumeration,
- rule-switch replay, dependency depth, and cross-mode interference certification.

The temporary validation workflow pinned `xxhash<4` because the repository's current unconstrained `xxhash` dependency resolves to 4.0.0, whose string hashing API is incompatible with the existing `template.py` call. That compatibility issue predates and is outside this PR; the PR itself changes only the three generated task files.