### PR TITLE
Add imperative Mesopy V3 with observed runnability

### DIFF
--- a/reasoning_core/resources/_imperative_mesopy_analysis.py
+++ b/reasoning_core/resources/_imperative_mesopy_analysis.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import random
+
+from ._imperative_mesopy_types import _REALISTIC_NAMES
+
+def _bound_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            names.add(node.name)
+            names.update(arg.arg for arg in node.args.args)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            names.add(node.id)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+    return names
+
+def _alpha_rename(module: ast.Module, entrypoint: str, rng: random.Random) -> tuple[ast.Module, str]:
+    module = copy.deepcopy(module)
+    bound = sorted(_bound_names(module))
+    pool = list(_REALISTIC_NAMES)
+    rng.shuffle(pool)
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+    for old in bound:
+        while pool:
+            candidate = pool.pop()
+            if candidate not in used:
+                break
+        else:
+            candidate = f"item{len(mapping) + 1}"
+        used.add(candidate)
+        mapping[old] = candidate
+
+    class Rename(ast.NodeTransformer):
+        def visit_FunctionDef(self, node):
+            node.name = mapping.get(node.name, node.name)
+            for arg in node.args.args:
+                arg.arg = mapping.get(arg.arg, arg.arg)
+            self.generic_visit(node)
+            return node
+
+        def visit_arg(self, node):
+            node.arg = mapping.get(node.arg, node.arg)
+            return node
+
+        def visit_Name(self, node):
+            node.id = mapping.get(node.id, node.id)
+            return node
+
+    module = Rename().visit(module)
+    ast.fix_missing_locations(module)
+    return module, mapping.get(entrypoint, entrypoint)
+
+def structural_fingerprint(code: str) -> str:
+    tree = ast.parse(code)
+    mapping: dict[str, str] = {}
+
+    def anon(name: str) -> str:
+        if name not in mapping:
+            mapping[name] = f"v{len(mapping)}"
+        return mapping[name]
+
+    bound = _bound_names(tree)
+
+    class Normalize(ast.NodeTransformer):
+        def visit_FunctionDef(self, node):
+            node.name = anon(node.name)
+            self.generic_visit(node)
+            return node
+
+        def visit_arg(self, node):
+            node.arg = anon(node.arg)
+            return node
+
+        def visit_Name(self, node):
+            if node.id in bound:
+                node.id = anon(node.id)
+            return node
+
+        def visit_Constant(self, node):
+            if isinstance(node.value, bool) or node.value is None:
+                return node
+            if isinstance(node.value, int):
+                return ast.copy_location(ast.Constant(0), node)
+            if isinstance(node.value, str):
+                return ast.copy_location(ast.Constant(""), node)
+            return node
+
+    norm = Normalize().visit(tree)
+    ast.fix_missing_locations(norm)
+    dump = ast.dump(norm, annotate_fields=False, include_attributes=False)
+    return hashlib.sha256(dump.encode()).hexdigest()
+
+def _rw(stmt: ast.AST) -> tuple[set[str], set[str]]:
+    reads: set[str] = set()
+    writes: set[str] = set()
+    for node in ast.walk(stmt):
+        if isinstance(node, ast.Name):
+            if isinstance(node.ctx, ast.Load):
+                reads.add(node.id)
+            elif isinstance(node.ctx, ast.Store):
+                writes.add(node.id)
+    return reads, writes
+
+def _has_effect(stmt: ast.stmt) -> bool:
+    if isinstance(stmt, (ast.Return, ast.Raise, ast.Try)):
+        return True
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        return True
+    for node in ast.walk(stmt):
+        if isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Subscript):
+            return True
+        if isinstance(node, ast.Assign) and any(isinstance(t, ast.Subscript) for t in node.targets):
+            return True
+    return False
+
+def _dependency_depth(fn: ast.FunctionDef) -> int:
+    def block(stmts: list[ast.stmt], incoming: dict[str, int]) -> tuple[dict[str, int], int]:
+        depths = dict(incoming)
+        returned = 0
+        for stmt in stmts:
+            if isinstance(stmt, ast.Return):
+                reads, _ = _rw(stmt)
+                returned = max(returned, 1 + max((depths.get(name, 0) for name in reads), default=0))
+                continue
+            if isinstance(stmt, ast.If):
+                yes, yes_ret = block(stmt.body, depths)
+                no, no_ret = block(stmt.orelse, depths)
+                for name in set(yes) | set(no):
+                    depths[name] = max(depths.get(name, 0), yes.get(name, 0), no.get(name, 0))
+                returned = max(returned, yes_ret, no_ret)
+                continue
+            if isinstance(stmt, (ast.For, ast.While)):
+                child, child_ret = block(stmt.body, depths)
+                for name, value in child.items():
+                    depths[name] = max(depths.get(name, 0), value)
+                returned = max(returned, child_ret)
+                continue
+            if isinstance(stmt, ast.Try):
+                branches = [block(stmt.body, depths)]
+                branches += [block(handler.body, depths) for handler in stmt.handlers]
+                if stmt.finalbody:
+                    branches.append(block(stmt.finalbody, depths))
+                for child, child_ret in branches:
+                    for name, value in child.items():
+                        depths[name] = max(depths.get(name, 0), value)
+                    returned = max(returned, child_ret)
+                continue
+            reads, writes = _rw(stmt)
+            base = max((depths.get(name, 0) for name in reads), default=0)
+            for name in writes:
+                if isinstance(stmt, ast.AugAssign) and isinstance(stmt.target, ast.Name) and stmt.target.id == name:
+                    base = max(base, depths.get(name, 0))
+                depths[name] = max(depths.get(name, 0), base + 1)
+        return depths, returned
+
+    initial = {arg.arg: 0 for arg in fn.args.args}
+    _, returned = block(fn.body, initial)
+    return returned
+
+def _liveness_metrics(fn: ast.FunctionDef) -> dict:
+    total = 0
+    live = 0
+    max_slice_depth = 0
+
+    def slice_block(stmts: list[ast.stmt], live_names: set[str], depth: int = 0) -> set[str]:
+        nonlocal total, live, max_slice_depth
+        current = set(live_names)
+        for stmt in reversed(stmts):
+            total += 1
+            if isinstance(stmt, ast.Return):
+                reads, _ = _rw(stmt)
+                current |= reads
+                live += 1
+                max_slice_depth = max(max_slice_depth, depth + 1)
+                continue
+
+            if isinstance(stmt, ast.If):
+                before = set(current)
+                yes = slice_block(stmt.body, set(current), depth + 1)
+                no = slice_block(stmt.orelse, set(current), depth + 1)
+                if yes != before or no != before or _has_effect(stmt):
+                    cond_reads, _ = _rw(stmt.test)
+                    current |= yes | no | cond_reads
+                    live += 1
+                    max_slice_depth = max(max_slice_depth, depth + 1)
+                continue
+
+            if isinstance(stmt, (ast.For, ast.While)):
+                before = set(current)
+                body_live = slice_block(stmt.body, set(current), depth + 1)
+                if body_live != before or _has_effect(stmt):
+                    reads, writes = _rw(stmt)
+                    current |= body_live | reads
+                    current -= {w for w in writes if w not in before}
+                    live += 1
+                    max_slice_depth = max(max_slice_depth, depth + 1)
+                continue
+
+            if isinstance(stmt, ast.Try):
+                branches = [slice_block(stmt.body, set(current), depth + 1)]
+                branches += [slice_block(h.body, set(current), depth + 1) for h in stmt.handlers]
+                branches.append(slice_block(stmt.finalbody, set(current), depth + 1))
+                current |= set().union(*branches)
+                live += 1
+                max_slice_depth = max(max_slice_depth, depth + 1)
+                continue
+
+            reads, writes = _rw(stmt)
+            needed = bool(writes & current) or _has_effect(stmt)
+            if needed:
+                live += 1
+                current -= writes
+                current |= reads
+                max_slice_depth = max(max_slice_depth, depth + 1)
+        return current
+
+    slice_block(fn.body, set())
+    return {
+        "live_statements": live,
+        "total_statements": total,
+        "live_fraction": live / total if total else 1.0,
+        "backward_slice_depth": _dependency_depth(fn),
+        "control_slice_depth": max_slice_depth,
+    }
+
+def _structural_features(tree: ast.AST) -> dict:
+    nodes = list(ast.walk(tree))
+
+    def depth(node: ast.AST) -> int:
+        children = list(ast.iter_child_nodes(node))
+        return 1 + max((depth(child) for child in children), default=0)
+
+    def control_depth(node: ast.AST, current: int = 0) -> int:
+        here = current + int(isinstance(node, (ast.If, ast.For, ast.While, ast.Try)))
+        return max([here] + [control_depth(child, here) for child in ast.iter_child_nodes(node)])
+
+    funcs = [n for n in nodes if isinstance(n, ast.FunctionDef)]
+    fn_names = {f.name for f in funcs}
+    edges: set[tuple[str, str]] = set()
+
+    class Calls(ast.NodeVisitor):
+        current: str | None = None
+
+        def visit_FunctionDef(self, node):
+            prev, self.current = self.current, node.name
+            self.generic_visit(node)
+            self.current = prev
+
+        def visit_Call(self, node):
+            if self.current and isinstance(node.func, ast.Name) and node.func.id in fn_names:
+                edges.add((self.current, node.func.id))
+            self.generic_visit(node)
+
+    Calls().visit(tree)
+
+    def longest(src: str, seen: set[str]) -> int:
+        nxt = [b for a, b in edges if a == src and b not in seen]
+        return 1 + max((longest(x, seen | {x}) for x in nxt), default=0)
+
+    return {
+        "ast_nodes": len(nodes),
+        "ast_depth": depth(tree),
+        "control_depth": control_depth(tree),
+        "functions": len(funcs),
+        "call_depth": max((longest(f.name, {f.name}) for f in funcs), default=0),
+        "loops": sum(isinstance(n, (ast.For, ast.While)) for n in nodes),
+        "branches": sum(isinstance(n, ast.If) for n in nodes),
+        "try_blocks": sum(isinstance(n, ast.Try) for n in nodes),
+        "mutations": sum(
+            isinstance(n, ast.AugAssign) or (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and n.func.attr in {"append", "insert", "pop", "reverse"}
+            )
+            for n in nodes
+        ),
+    }

--- a/reasoning_core/resources/_imperative_mesopy_expr.py
+++ b/reasoning_core/resources/_imperative_mesopy_expr.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import ast
+
+from ._imperative_mesopy_types import BOOL, DICT_INT, INT, LIST_INT, ExprSpec, Risk, _Env
+
+
+def _combine_int(a: ExprSpec, b: ExprSpec, op: ast.operator) -> ExprSpec:
+    return ExprSpec(
+        ast.BinOp(a.node, op, b.node),
+        INT,
+        a.deps | b.deps,
+        a.risks + b.risks,
+        1 + max(a.depth, b.depth),
+    )
+
+
+class _ExpressionMixin:
+    def _leaf_int(self, env: _Env, required: set[str] | None = None) -> ExprSpec:
+        required = set(required or ())
+        candidates = env.names(INT)
+        if required:
+            covering = [n for n in candidates if required <= set(env.info(n).deps)]
+            if covering:
+                name = self.rng.choice(covering)
+                info = env.info(name)
+                return ExprSpec(ast.Name(name, ast.Load()), INT, info.deps, (), info.depth)
+            param = self.rng.choice(sorted(required))
+            if param in env.vars:
+                info = env.info(param)
+                return ExprSpec(ast.Name(param, ast.Load()), INT, info.deps, (), info.depth)
+        if candidates and self.rng.random() < 0.76:
+            name = self.rng.choice(candidates)
+            info = env.info(name)
+            return ExprSpec(ast.Name(name, ast.Load()), INT, info.deps, (), info.depth)
+        return ExprSpec(ast.Constant(self.rng.randint(-self.config.magnitude, self.config.magnitude)), INT)
+
+    def _gen_int_expr(
+        self,
+        env: _Env,
+        depth: int,
+        required: set[str] | None = None,
+    ) -> ExprSpec:
+        required = set(required or ())
+        if depth <= 0:
+            if len(required) <= 1:
+                return self._leaf_int(env, required)
+            deps = sorted(required)
+            mid = max(1, len(deps) // 2)
+            left = self._gen_int_expr(env, 0, set(deps[:mid]))
+            right = self._gen_int_expr(env, 0, set(deps[mid:]))
+            return _combine_int(left, right, ast.Add())
+
+        kinds = ["leaf", "bin", "ternary", "call"]
+        if env.names(LIST_INT):
+            kinds += ["index", "length", "list_index"]
+        if env.names(DICT_INT):
+            kinds += ["dict_get"]
+        kind = self.rng.choice(kinds)
+        if required and kind in {"index", "list_index", "dict_get", "call"} and self.rng.random() < 0.45:
+            kind = "bin"
+
+        if kind == "leaf":
+            return self._leaf_int(env, required)
+
+        if kind == "bin":
+            deps = list(required)
+            self.rng.shuffle(deps)
+            cut = self.rng.randint(0, len(deps)) if deps else 0
+            left = self._gen_int_expr(env, depth - 1, set(deps[:cut]))
+            right = self._gen_int_expr(env, depth - 1, set(deps[cut:]))
+            op = self.rng.choice((ast.Add(), ast.Sub(), ast.Mult(), ast.FloorDiv(), ast.Mod()))
+            risks = left.risks + right.risks
+            right_node = right.node
+            if isinstance(op, (ast.FloorDiv, ast.Mod)):
+                if not self._take_risk():
+                    right_node = ast.BinOp(
+                        ast.Call(ast.Name("abs", ast.Load()), [right.node], []),
+                        ast.Add(),
+                        ast.Constant(1),
+                    )
+                else:
+                    risks += (Risk("ZeroDivisionError", right.deps),)
+            elif isinstance(op, ast.Mult) and self.rng.random() < 0.55:
+                right_node = ast.Constant(self.rng.choice((-3, -2, -1, 1, 2, 3)))
+            return ExprSpec(
+                ast.BinOp(left.node, op, right_node),
+                INT,
+                left.deps | right.deps,
+                risks,
+                1 + max(left.depth, right.depth),
+            )
+
+        if kind == "ternary":
+            cond = self._gen_bool_expr(env, depth - 1)
+            yes = self._gen_int_expr(env, depth - 1, required)
+            no = self._gen_int_expr(env, depth - 1, required)
+            return ExprSpec(
+                ast.IfExp(cond.node, yes.node, no.node),
+                INT,
+                cond.deps | yes.deps | no.deps,
+                cond.risks + yes.risks + no.risks,
+                1 + max(cond.depth, yes.depth, no.depth),
+            )
+
+        if kind == "call" and env.functions:
+            fn = self.rng.choice(env.functions)
+            if fn.startswith("recur"):
+                seed = self._gen_int_expr(env, max(0, depth - 1), required)
+                rank_raw = self._gen_int_expr(env, max(0, depth - 1))
+                rank = ast.BinOp(
+                    ast.Call(ast.Name("abs", ast.Load()), [rank_raw.node], []),
+                    ast.Mod(),
+                    ast.Constant(max(2, self.config.magnitude)),
+                )
+                return ExprSpec(
+                    ast.Call(ast.Name(fn, ast.Load()), [rank, seed.node], []),
+                    INT,
+                    seed.deps | rank_raw.deps,
+                    seed.risks + rank_raw.risks,
+                    1 + max(seed.depth, rank_raw.depth),
+                )
+            a = self._gen_int_expr(env, depth - 1, required)
+            b = self._gen_int_expr(env, depth - 1)
+            return ExprSpec(
+                ast.Call(ast.Name(fn, ast.Load()), [a.node, b.node], []),
+                INT,
+                a.deps | b.deps,
+                a.risks + b.risks,
+                1 + max(a.depth, b.depth),
+            )
+
+        if kind == "index":
+            name = self.rng.choice(env.names(LIST_INT))
+            info = env.info(name)
+            idx = self._gen_int_expr(env, depth - 1, required)
+            node = idx.node
+            risks = idx.risks
+            if not self._take_risk() and info.length:
+                node = ast.BinOp(
+                    ast.Call(ast.Name("abs", ast.Load()), [idx.node], []),
+                    ast.Mod(),
+                    ast.Constant(info.length),
+                )
+            else:
+                risks += (Risk("IndexError", idx.deps),)
+            return ExprSpec(
+                ast.Subscript(ast.Name(name, ast.Load()), node, ast.Load()),
+                INT,
+                info.deps | idx.deps,
+                risks,
+                max(info.depth, idx.depth) + 1,
+            )
+
+        if kind == "length":
+            name = self.rng.choice(env.names(LIST_INT))
+            info = env.info(name)
+            return ExprSpec(
+                ast.Call(ast.Name("len", ast.Load()), [ast.Name(name, ast.Load())], []),
+                INT,
+                info.deps,
+                (),
+                info.depth + 1,
+            )
+
+        if kind == "list_index":
+            name = self.rng.choice(env.names(LIST_INT))
+            info = env.info(name)
+            value = self._gen_int_expr(env, depth - 1, required)
+            if not self._take_risk() and info.length:
+                value_node = ast.Subscript(
+                    ast.Name(name, ast.Load()),
+                    ast.Constant(self.rng.randrange(info.length)),
+                    ast.Load(),
+                )
+                risks = value.risks
+            else:
+                value_node = value.node
+                risks = value.risks + (Risk("ValueError", value.deps),)
+            return ExprSpec(
+                ast.Call(ast.Attribute(ast.Name(name, ast.Load()), "index", ast.Load()), [value_node], []),
+                INT,
+                info.deps | value.deps,
+                risks,
+                max(info.depth, value.depth) + 1,
+            )
+
+        if kind == "dict_get" and env.names(DICT_INT):
+            name = self.rng.choice(env.names(DICT_INT))
+            info = env.info(name)
+            key = self._gen_int_expr(env, depth - 1, required)
+            if not self._take_risk():
+                node = ast.Call(
+                    ast.Attribute(ast.Name(name, ast.Load()), "get", ast.Load()),
+                    [key.node, ast.Constant(0)],
+                    [],
+                )
+                risks = key.risks
+            else:
+                node = ast.Subscript(ast.Name(name, ast.Load()), key.node, ast.Load())
+                risks = key.risks + (Risk("KeyError", key.deps),)
+            return ExprSpec(node, INT, info.deps | key.deps, risks, max(info.depth, key.depth) + 1)
+
+        return self._leaf_int(env, required)
+
+    def _gen_bool_expr(self, env: _Env, depth: int) -> ExprSpec:
+        if depth <= 0 or self.rng.random() < 0.55:
+            a = self._gen_int_expr(env, max(0, depth - 1))
+            b = self._gen_int_expr(env, max(0, depth - 1))
+            return ExprSpec(
+                ast.Compare(a.node, [self.rng.choice((ast.Lt(), ast.LtE(), ast.Gt(), ast.GtE(), ast.Eq(), ast.NotEq()))], [b.node]),
+                BOOL,
+                a.deps | b.deps,
+                a.risks + b.risks,
+                1 + max(a.depth, b.depth),
+            )
+        a = self._gen_bool_expr(env, depth - 1)
+        b = self._gen_bool_expr(env, depth - 1)
+        return ExprSpec(
+            ast.BoolOp(self.rng.choice((ast.And(), ast.Or())), [a.node, b.node]),
+            BOOL,
+            a.deps | b.deps,
+            a.risks + b.risks,
+            1 + max(a.depth, b.depth),
+        )
+
+    def _gen_list_expr(self, env: _Env, depth: int, required: set[str] | None = None) -> ExprSpec:
+        required = set(required or ())
+        if env.names(LIST_INT) and self.rng.random() < 0.45:
+            name = self.rng.choice(env.names(LIST_INT))
+            info = env.info(name)
+            if self.rng.random() < 0.55:
+                node = ast.Subscript(
+                    ast.Name(name, ast.Load()),
+                    ast.Slice(None, None, self.rng.choice((None, ast.Constant(2), ast.Constant(-1)))),
+                    ast.Load(),
+                )
+            else:
+                node = ast.Name(name, ast.Load())
+            return ExprSpec(node, LIST_INT, info.deps, (), info.depth + 1)
+        n = self.rng.randint(2, max(2, self.config.list_size[1]))
+        parts = self._covering_exprs(env, n, max(0, depth - 1), required)
+        return ExprSpec(
+            ast.List([p.node for p in parts], ast.Load()),
+            LIST_INT,
+            frozenset().union(*(p.deps for p in parts)) if parts else frozenset(),
+            tuple(r for p in parts for r in p.risks),
+            1 + max((p.depth for p in parts), default=0),
+        )
+
+    def _gen_dict_expr(self, env: _Env, depth: int) -> ExprSpec:
+        size = self.rng.randint(2, 4)
+        values = [self._gen_int_expr(env, max(0, depth - 1)) for _ in range(size)]
+        return ExprSpec(
+            ast.Dict([ast.Constant(i) for i in range(size)], [x.node for x in values]),
+            DICT_INT,
+            frozenset().union(*(x.deps for x in values)) if values else frozenset(),
+            tuple(r for x in values for r in x.risks),
+            1 + max((x.depth for x in values), default=0),
+        )
+
+    def _force_risky_int_expr(self, env: _Env, depth: int) -> ExprSpec:
+        choices = []
+        if env.names(LIST_INT):
+            choices += ["index", "list_index"]
+        if env.names(DICT_INT):
+            choices += ["dict"]
+        choices += ["division"]
+        kind = self.rng.choice(choices)
+        if kind == "division":
+            a = self._gen_int_expr(env, max(0, depth - 1))
+            b = self._gen_int_expr(env, max(0, depth - 1))
+            return ExprSpec(
+                ast.BinOp(a.node, ast.FloorDiv(), b.node),
+                INT,
+                a.deps | b.deps,
+                a.risks + b.risks + (Risk("ZeroDivisionError", b.deps),),
+                1 + max(a.depth, b.depth),
+            )
+        if kind == "index":
+            name = self.rng.choice(env.names(LIST_INT))
+            idx = self._gen_int_expr(env, max(0, depth - 1))
+            info = env.info(name)
+            return ExprSpec(
+                ast.Subscript(ast.Name(name, ast.Load()), idx.node, ast.Load()),
+                INT,
+                info.deps | idx.deps,
+                idx.risks + (Risk("IndexError", idx.deps),),
+                max(info.depth, idx.depth) + 1,
+            )
+        if kind == "list_index":
+            name = self.rng.choice(env.names(LIST_INT))
+            value = self._gen_int_expr(env, max(0, depth - 1))
+            info = env.info(name)
+            return ExprSpec(
+                ast.Call(ast.Attribute(ast.Name(name, ast.Load()), "index", ast.Load()), [value.node], []),
+                INT,
+                info.deps | value.deps,
+                value.risks + (Risk("ValueError", value.deps),),
+                max(info.depth, value.depth) + 1,
+            )
+        name = self.rng.choice(env.names(DICT_INT))
+        key = self._gen_int_expr(env, max(0, depth - 1))
+        info = env.info(name)
+        return ExprSpec(
+            ast.Subscript(ast.Name(name, ast.Load()), key.node, ast.Load()),
+            INT,
+            info.deps | key.deps,
+            key.risks + (Risk("KeyError", key.deps),),
+            max(info.depth, key.depth) + 1,
+        )

--- a/reasoning_core/resources/_imperative_mesopy_generation.py
+++ b/reasoning_core/resources/_imperative_mesopy_generation.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import ast
+import random
+
+from ._imperative_mesopy_analysis import _alpha_rename, _liveness_metrics, _structural_features, structural_fingerprint
+from ._imperative_mesopy_types import (
+    CONTROLLED_PHENOMENA, INT, LIST_INT, OBSERVED_ERRORS, PHENOMENA, TUPLE_INT,
+    ExprSpec, MesopyComplexity, MesopyConfig, MesopyGoal, MesopySample, Risk, VarInfo, _Env, _Names,
+)
+
+
+class _GenerationMixin:
+    def __init__(self, config: MesopyConfig | None = None, seed: int | None = None):
+        self.config = config or MesopyConfig()
+        self.rng = random.Random(seed)
+        self.names = _Names()
+        self._seen: set[str] = set()
+        self._risk_remaining = 0
+
+    def execution(self, **kwargs) -> MesopySample:
+        return self.generate(MesopyGoal(runnable=True, **kwargs))
+
+    def runnability_pair(self, **kwargs) -> MesopySample:
+        return self.generate(MesopyGoal(runnable=None, paired_runnability=True, **kwargs))
+
+    def generate(self, goal: MesopyGoal | None = None) -> MesopySample:
+        goal = goal or MesopyGoal()
+        self._validate_goal(goal)
+        for _ in range(self.config.max_attempts):
+            candidate = self._build_candidate(goal)
+            if candidate is None:
+                continue
+            if self.config.deduplicate and candidate.fingerprint in self._seen:
+                continue
+            self._seen.add(candidate.fingerprint)
+            return candidate
+        raise RuntimeError(f"failed to generate imperative Mesopy sample: {goal}")
+
+    def _validate_goal(self, goal: MesopyGoal) -> None:
+        if goal.error is not None and goal.error not in OBSERVED_ERRORS:
+            raise ValueError(f"supported observed errors: {', '.join(OBSERVED_ERRORS)}")
+        if goal.require_recursion and not goal.allow_recursion:
+            raise ValueError("require_recursion needs allow_recursion=True")
+        if goal.input_arity is not None and goal.input_arity < 0:
+            raise ValueError("input_arity must be non-negative")
+        if (goal.runnable is False or goal.paired_runnability or goal.error) and goal.input_arity == 0:
+            raise ValueError("runnability goals need at least one input")
+        if goal.result_kind not in (None, INT, LIST_INT, TUPLE_INT):
+            raise ValueError(f"unsupported result_kind: {goal.result_kind}")
+        unknown = set(goal.phenomena) - set(PHENOMENA)
+        if unknown:
+            raise ValueError(f"unknown phenomena: {sorted(unknown)}")
+
+    def _build_candidate(self, goal: MesopyGoal) -> MesopySample | None:
+        self.names = _Names()
+        cfg = self.config
+        cx = goal.complexity or cfg.complexity
+        arity = goal.input_arity
+        if arity is None:
+            lo, hi = cfg.input_arity
+            if goal.runnable is False or goal.paired_runnability or goal.error:
+                lo = max(1, lo)
+            arity = self.rng.randint(lo, hi)
+        self._risk_remaining = 0
+        params = [self.names.take("arg") for _ in range(arity)]
+        env = _Env(params)
+
+        recursive = goal.allow_recursion and (
+            goal.require_recursion
+            or "recursion" in goal.phenomena
+            or self.rng.random() < cfg.recursion_rate
+        )
+        helpers, helper_names = self._gen_helpers(cx, recursive)
+        env.functions = helper_names
+        self._risk_remaining = min(cfg.max_risk_sites, max(1, 1 + cx.statements // 8))
+
+        body: list[ast.stmt] = []
+        phenomena: set[str] = set()
+        risks: list[Risk] = []
+
+        list_len = self.rng.randint(*cfg.list_size)
+        state = self.names.take("seq")
+        state_exprs = self._covering_exprs(env, list_len, cx.expr_depth, set(params))
+        body.append(ast.Assign([ast.Name(state, ast.Store())], ast.List([x.node for x in state_exprs], ast.Load())))
+        state_deps = frozenset().union(*(x.deps for x in state_exprs)) if state_exprs else frozenset()
+        env.add(state, VarInfo(LIST_INT, state_deps, 1, list_len))
+        for x in state_exprs:
+            risks.extend(x.risks)
+
+        focus = self.names.take("acc")
+        focus_spec = self._gen_int_expr(env, cx.expr_depth, required=set(params))
+        body.append(ast.Assign([ast.Name(focus, ast.Store())], focus_spec.node))
+        env.add(focus, focus_spec)
+        risks.extend(focus_spec.risks)
+
+        requested = list(goal.phenomena)
+        ordinary_count = max(2, cx.statements)
+        for _ in range(ordinary_count):
+            nodes, tags, new_risks = self._gen_stmt(
+                env, focus, state, cx.control_depth, cx.expr_depth, cx
+            )
+            body.extend(nodes)
+            phenomena.update(tags)
+            risks.extend(new_risks)
+
+            if self.rng.random() < cfg.phenomenon_rate:
+                choices = [p for p in CONTROLLED_PHENOMENA if p not in phenomena]
+                if choices:
+                    p = self.rng.choice(choices)
+                    nodes, new_risks = self._phenomenon(p, env, focus, state, cx)
+                    self._splice(body, nodes)
+                    phenomena.add(p)
+                    risks.extend(new_risks)
+
+        for p in requested:
+            if p == "recursion":
+                phenomena.add("recursion")
+                continue
+            if p in phenomena:
+                continue
+            if p in ("conditional_flow", "try_except", "early_return", "comprehension", "mapping"):
+                nodes, tags, new_risks = self._force_structural_phenomenon(p, env, focus, state, cx)
+                self._splice(body, nodes)
+                phenomena.update(tags)
+                risks.extend(new_risks)
+            else:
+                nodes, new_risks = self._phenomenon(p, env, focus, state, cx)
+                self._splice(body, nodes)
+                phenomena.add(p)
+                risks.extend(new_risks)
+
+        if recursive:
+            phenomena.add("recursion")
+
+        # Keep semantic depth productive without a conspicuous terminal padding chain:
+        # dependency-preserving updates are inserted among existing top-level statements.
+        while env.info(focus).depth < cx.dataflow_depth:
+            expr = self._gen_int_expr(env, max(1, cx.expr_depth - 1), required=set(params))
+            node = ast.Assign(
+                [ast.Name(focus, ast.Store())],
+                ast.BinOp(ast.Name(focus, ast.Load()), self.rng.choice((ast.Add(), ast.Sub())), expr.node),
+            )
+            combined = VarInfo(
+                INT,
+                env.info(focus).deps | expr.deps,
+                max(env.info(focus).depth, expr.depth) + 1,
+            )
+            env.add(focus, combined)
+            risks.extend(expr.risks)
+            insert_at = self.rng.randrange(max(1, len(body) // 2), len(body) + 1)
+            body.insert(insert_at, node)
+
+        result_kind = goal.result_kind or self.rng.choice((INT, INT, LIST_INT, TUPLE_INT))
+        return_spec = self._return_expr(result_kind, env, focus, state, cx.expr_depth, set(params))
+        body.append(ast.Return(return_spec.node))
+        risks.extend(return_spec.risks)
+
+        endpoint = "endpoint"
+        endpoint_def = ast.FunctionDef(
+            endpoint,
+            ast.arguments([], [ast.arg(p) for p in params], None, [], [], None, []),
+            body,
+            [],
+        )
+        module_body = helpers + [endpoint_def]
+        self.rng.shuffle(module_body)
+        module = ast.fix_missing_locations(ast.Module(module_body, []))
+
+        liveness = _liveness_metrics(endpoint_def)
+        if liveness["live_fraction"] < goal.min_live_fraction:
+            return None
+
+        code = ast.unparse(module) + "\n"
+
+        probes = self._probe_args(arity, cfg.probe_count)
+        outcomes = self._execute_many(code, endpoint, probes)
+        selected = self._select_outcomes(goal, outcomes)
+        if selected is None:
+            return None
+
+        sensitivity, diversity = self._probe_metrics(code, endpoint, selected[0], arity)
+        if sensitivity < goal.min_param_sensitivity:
+            return None
+
+        anonymize = cfg.anonymize_names if goal.anonymize_names is None else goal.anonymize_names
+        if anonymize:
+            renamed, renamed_entrypoint = _alpha_rename(module, endpoint, self.rng)
+            renamed_code = ast.unparse(renamed) + "\n"
+            check = self._execute_many(renamed_code, renamed_entrypoint, [x.args for x in selected])
+            if any(
+                (a.ok, a.value, a.error) != (b.ok, b.value, b.error)
+                for a, b in zip(selected, check)
+            ):
+                return None
+            module, code, endpoint = renamed, renamed_code, renamed_entrypoint
+
+        profile = selected[0]
+        if cfg.profile_accepted:
+            profile = self._profile(code, endpoint, selected[0].args, cfg.max_profile_steps)
+            if profile.ok != selected[0].ok or profile.value != selected[0].value or profile.error != selected[0].error:
+                return None
+            selected = (profile,) + tuple(selected[1:])
+
+        fingerprint = structural_fingerprint(code)
+        features = _structural_features(module)
+        features.update(liveness)
+        features.update(
+            dataflow_depth=env.info(focus).depth,
+            recursive=recursive,
+            input_arity=arity,
+            result_kind=result_kind,
+            risk_sites=len(risks),
+            risk_kinds=tuple(sorted({r.kind for r in risks})),
+            probe_errors=tuple(sorted({x.error for x in outcomes if x.error})),
+            probe_output_diversity=diversity,
+            param_sensitivity=sensitivity,
+            dynamic_steps=profile.steps,
+            dynamic_lines=profile.distinct_lines,
+        )
+        return MesopySample(
+            code,
+            endpoint,
+            tuple(selected),
+            tuple(sorted(phenomena)),
+            features,
+            fingerprint,
+        )
+
+    def _take_risk(self) -> bool:
+        if self._risk_remaining <= 0 or self.rng.random() >= self.config.risk_rate:
+            return False
+        self._risk_remaining -= 1
+        return True
+
+    def _covering_exprs(
+        self, env: _Env, count: int, depth: int, required: set[str]
+    ) -> list[ExprSpec]:
+        buckets = [set() for _ in range(count)]
+        for i, dep in enumerate(sorted(required)):
+            buckets[i % count].add(dep)
+        return [self._gen_int_expr(env, depth, required=b) for b in buckets]
+
+    def _gen_helpers(self, cx: MesopyComplexity, recursive: bool) -> tuple[list[ast.stmt], list[str]]:
+        helpers: list[ast.stmt] = []
+        names: list[str] = []
+        for i in range(max(0, cx.functions)):
+            fn = self.names.take("fn")
+            x = self.names.take("p")
+            y = self.names.take("p")
+            local = _Env((x, y))
+            local.functions = names[:]
+            expr = self._gen_int_expr(local, max(1, cx.expr_depth - 1), required={x})
+            if names and i <= cx.call_depth:
+                prev = self.rng.choice(names)
+                call = ast.Call(ast.Name(prev, ast.Load()), [ast.Name(x, ast.Load()), ast.Name(y, ast.Load())], [])
+                expr = ExprSpec(
+                    ast.BinOp(call, self.rng.choice((ast.Add(), ast.Sub())), expr.node),
+                    INT,
+                    expr.deps | {x, y},
+                    expr.risks,
+                    expr.depth + 1,
+                )
+            helpers.append(ast.FunctionDef(
+                fn,
+                ast.arguments([], [ast.arg(x), ast.arg(y)], None, [], [], None, []),
+                [ast.Return(expr.node)],
+                [],
+            ))
+            names.append(fn)
+
+        if recursive:
+            fn = self.names.take("recur")
+            n = self.names.take("n")
+            z = self.names.take("z")
+            base = ast.If(
+                ast.Compare(ast.Name(n, ast.Load()), [ast.LtE()], [ast.Constant(0)]),
+                [ast.Return(ast.Name(z, ast.Load()))],
+                [],
+            )
+            step = ast.Call(
+                ast.Name(fn, ast.Load()),
+                [
+                    ast.BinOp(ast.Name(n, ast.Load()), ast.Sub(), ast.Constant(1)),
+                    ast.BinOp(ast.Name(z, ast.Load()), ast.Add(), ast.Name(n, ast.Load())),
+                ],
+                [],
+            )
+            helpers.append(ast.FunctionDef(
+                fn,
+                ast.arguments([], [ast.arg(n), ast.arg(z)], None, [], [], None, []),
+                [base, ast.Return(step)],
+                [],
+            ))
+            names.append(fn)
+        return helpers, names
+
+    def _splice(self, body: list[ast.stmt], nodes: list[ast.stmt]) -> None:
+        if not nodes:
+            return
+        # Do not place before the two initial state/focus bindings.
+        pos = self.rng.randint(min(2, len(body)), len(body))
+        body[pos:pos] = nodes
+
+    def _return_expr(
+        self,
+        kind: str,
+        env: _Env,
+        focus: str,
+        state: str,
+        depth: int,
+        required: set[str],
+    ) -> ExprSpec:
+        focus_info = env.info(focus)
+        if kind == LIST_INT:
+            # Include focus in the returned list so scalar control/dataflow remains relevant.
+            state_info = env.info(state)
+            node = ast.BinOp(
+                ast.Name(state, ast.Load()),
+                ast.Add(),
+                ast.List([ast.Name(focus, ast.Load())], ast.Load()),
+            )
+            return ExprSpec(node, LIST_INT, state_info.deps | focus_info.deps, (), max(state_info.depth, focus_info.depth) + 1)
+        if kind == TUPLE_INT:
+            second = self._gen_int_expr(env, min(depth, 2), required)
+            return ExprSpec(
+                ast.Tuple([ast.Name(focus, ast.Load()), second.node], ast.Load()),
+                TUPLE_INT,
+                focus_info.deps | second.deps,
+                second.risks,
+                max(focus_info.depth, second.depth) + 1,
+            )
+        if required <= set(focus_info.deps) and self.rng.random() < 0.75:
+            return ExprSpec(ast.Name(focus, ast.Load()), INT, focus_info.deps, (), focus_info.depth)
+        extra = self._gen_int_expr(env, min(depth, 2), required)
+        return ExprSpec(
+            ast.BinOp(ast.Name(focus, ast.Load()), ast.Add(), extra.node),
+            INT,
+            focus_info.deps | extra.deps,
+            extra.risks,
+            max(focus_info.depth, extra.depth) + 1,
+        )

--- a/reasoning_core/resources/_imperative_mesopy_phenomena.py
+++ b/reasoning_core/resources/_imperative_mesopy_phenomena.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import ast
+
+from ._imperative_mesopy_types import LIST_INT, Risk, VarInfo, _Env, MesopyComplexity
+
+
+class _PhenomenaMixin:
+    def _phenomenon(
+        self,
+        phenomenon: str,
+        env: _Env,
+        focus: str,
+        state: str,
+        cx: MesopyComplexity,
+    ) -> tuple[list[ast.stmt], list[Risk]]:
+        rng = self.rng
+        risks: list[Risk] = []
+        if phenomenon == "aliasing":
+            alias = self.names.take("ref")
+            idx = rng.randrange(max(1, env.info(state).length or 1))
+            delta = rng.choice((-2, -1, 1, 2))
+            env.add(alias, VarInfo(LIST_INT, env.info(state).deps, env.info(state).depth, env.info(state).length))
+            return [
+                ast.Assign([ast.Name(alias, ast.Store())], ast.Name(state, ast.Load())),
+                ast.AugAssign(ast.Subscript(ast.Name(alias, ast.Load()), ast.Constant(idx), ast.Store()), ast.Add(), ast.Constant(delta)),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Subscript(ast.Name(state, ast.Load()), ast.Constant(idx), ast.Load())),
+            ], risks
+
+        if phenomenon == "rebinding_vs_aliasing":
+            alias = self.names.take("ref")
+            env.add(alias, VarInfo(LIST_INT, env.info(state).deps, env.info(state).depth, env.info(state).length))
+            idx = rng.randrange(max(1, env.info(state).length or 1))
+            if rng.random() < 0.5:
+                copy_node = ast.Subscript(ast.Name(state, ast.Load()), ast.Slice(None, None, None), ast.Load())
+            else:
+                copy_node = ast.Call(ast.Name("list", ast.Load()), [ast.Name(state, ast.Load())], [])
+            return [
+                ast.Assign([ast.Name(alias, ast.Store())], ast.Name(state, ast.Load())),
+                ast.Assign([ast.Name(state, ast.Store())], copy_node),
+                ast.AugAssign(ast.Subscript(ast.Name(alias, ast.Load()), ast.Constant(idx), ast.Store()), ast.Add(), ast.Constant(1)),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.BinOp(
+                    ast.Subscript(ast.Name(alias, ast.Load()), ast.Constant(idx), ast.Load()),
+                    ast.Sub(),
+                    ast.Subscript(ast.Name(state, ast.Load()), ast.Constant(idx), ast.Load()),
+                )),
+            ], risks
+
+        if phenomenon == "closure_late_binding":
+            funcs = self.names.take("funcs")
+            loop = self.names.take("i")
+            arg = self.names.take("z")
+            call_index = rng.choice((0, 1, 2))
+            lam = ast.Lambda(
+                ast.arguments([], [ast.arg(arg)], None, [], [], None, []),
+                ast.BinOp(ast.Name(arg, ast.Load()), ast.Add(), ast.Name(loop, ast.Load())),
+            )
+            return [
+                ast.Assign([ast.Name(funcs, ast.Store())], ast.List([], ast.Load())),
+                ast.For(
+                    ast.Name(loop, ast.Store()),
+                    ast.Call(ast.Name("range", ast.Load()), [ast.Constant(3)], []),
+                    [ast.Expr(ast.Call(ast.Attribute(ast.Name(funcs, ast.Load()), "append", ast.Load()), [lam], []))],
+                    [],
+                ),
+                ast.Assign([ast.Name(focus, ast.Store())], ast.Call(
+                    ast.Subscript(ast.Name(funcs, ast.Load()), ast.Constant(call_index), ast.Load()),
+                    [ast.Name(focus, ast.Load())],
+                    [],
+                )),
+            ], risks
+
+        if phenomenon == "default_capture":
+            bias = self.names.take("bias")
+            fn = self.names.take("inner")
+            z = self.names.take("z")
+            default = self.names.take("d")
+            c = rng.randint(1, 4)
+            return [
+                ast.Assign([ast.Name(bias, ast.Store())], ast.BinOp(ast.Name(focus, ast.Load()), ast.Mod(), ast.Constant(5))),
+                ast.FunctionDef(
+                    fn,
+                    ast.arguments([], [ast.arg(z), ast.arg(default)], None, [], [], None, [ast.Name(bias, ast.Load())]),
+                    [ast.Return(ast.BinOp(ast.Name(z, ast.Load()), ast.Add(), ast.Name(default, ast.Load())))],
+                    [],
+                ),
+                ast.AugAssign(ast.Name(bias, ast.Store()), ast.Add(), ast.Constant(c)),
+                ast.Assign([ast.Name(focus, ast.Store())], ast.Call(ast.Name(fn, ast.Load()), [ast.Name(focus, ast.Load())], [])),
+            ], risks
+
+        if phenomenon == "mutable_default":
+            fn = self.names.take("inner")
+            z = self.names.take("z")
+            box = self.names.take("box")
+            return [
+                ast.FunctionDef(
+                    fn,
+                    ast.arguments([], [ast.arg(z), ast.arg(box)], None, [], [], None, [ast.List([], ast.Load())]),
+                    [
+                        ast.Expr(ast.Call(ast.Attribute(ast.Name(box, ast.Load()), "append", ast.Load()), [ast.Name(z, ast.Load())], [])),
+                        ast.Return(ast.BinOp(ast.Name(z, ast.Load()), ast.Add(), ast.Call(ast.Name("len", ast.Load()), [ast.Name(box, ast.Load())], []))),
+                    ],
+                    [],
+                ),
+                ast.Assign([ast.Name(focus, ast.Store())], ast.Call(ast.Name(fn, ast.Load()), [ast.Name(focus, ast.Load())], [])),
+                ast.Assign([ast.Name(focus, ast.Store())], ast.Call(ast.Name(fn, ast.Load()), [ast.Name(focus, ast.Load())], [])),
+            ], risks
+
+        if phenomenon == "mutation_call":
+            fn = self.names.take("mut")
+            ys = self.names.take("ys")
+            idx = rng.randrange(max(1, env.info(state).length or 1))
+            return [
+                ast.FunctionDef(
+                    fn,
+                    ast.arguments([], [ast.arg(ys)], None, [], [], None, []),
+                    [
+                        ast.AugAssign(ast.Subscript(ast.Name(ys, ast.Load()), ast.Constant(idx), ast.Store()), ast.Add(), ast.Constant(1)),
+                        ast.Return(ast.Subscript(ast.Name(ys, ast.Load()), ast.Constant(idx), ast.Load())),
+                    ],
+                    [],
+                ),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Call(ast.Name(fn, ast.Load()), [ast.Name(state, ast.Load())], [])),
+            ], risks
+
+        if phenomenon == "loop_carried_state":
+            it = self.names.take("i")
+            return [ast.For(
+                ast.Name(it, ast.Store()),
+                ast.Call(ast.Name("range", ast.Load()), [ast.Constant(max(2, cx.loop_bound))], []),
+                [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Name(it, ast.Load()))],
+                [],
+            )], risks
+
+        raise ValueError(phenomenon)
+
+    def _force_structural_phenomenon(
+        self,
+        phenomenon: str,
+        env: _Env,
+        focus: str,
+        state: str,
+        cx: MesopyComplexity,
+    ) -> tuple[list[ast.stmt], set[str], list[Risk]]:
+        if phenomenon == "conditional_flow":
+            cond = self._gen_bool_expr(env, max(0, cx.expr_depth - 1))
+            a = self._gen_int_expr(env, max(0, cx.expr_depth - 1))
+            b = self._gen_int_expr(env, max(0, cx.expr_depth - 1))
+            return [ast.If(
+                cond.node,
+                [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), a.node)],
+                [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Sub(), b.node)],
+            )], {phenomenon}, list(cond.risks + a.risks + b.risks)
+        if phenomenon == "try_except":
+            risky = self._force_risky_int_expr(env, max(1, cx.expr_depth - 1))
+            exc = next(iter({r.kind for r in risky.risks}), "Exception")
+            return [ast.Try(
+                [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), risky.node)],
+                [ast.ExceptHandler(ast.Name(exc, ast.Load()), None, [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Sub(), ast.Constant(1))])],
+                [], [],
+            )], {phenomenon}, list(risky.risks)
+        if phenomenon == "early_return":
+            cond = self._gen_bool_expr(env, max(0, cx.expr_depth - 1))
+            return [ast.If(cond.node, [ast.Return(ast.Name(focus, ast.Load()))], [])], {phenomenon}, list(cond.risks)
+        if phenomenon == "comprehension":
+            it = self.names.take("i")
+            name = self.names.take("comp")
+            bound = max(2, cx.loop_bound)
+            env.add(name, VarInfo(LIST_INT, env.info(focus).deps, env.info(focus).depth + 1, bound))
+            return [
+                ast.Assign([ast.Name(name, ast.Store())], ast.ListComp(
+                    ast.BinOp(ast.Name(it, ast.Load()), ast.Add(), ast.Name(focus, ast.Load())),
+                    [ast.comprehension(ast.Name(it, ast.Store()), ast.Call(ast.Name("range", ast.Load()), [ast.Constant(bound)], []), [], 0)],
+                )),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Call(ast.Name("sum", ast.Load()), [ast.Name(name, ast.Load())], [])),
+            ], {phenomenon}, []
+        if phenomenon == "mapping":
+            expr = self._gen_dict_expr(env, cx.expr_depth)
+            name = self.names.take("map")
+            env.add(name, expr)
+            return [
+                ast.Assign([ast.Name(name, ast.Store())], expr.node),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Call(
+                    ast.Attribute(ast.Name(name, ast.Load()), "get", ast.Load()), [ast.Constant(0), ast.Constant(0)], []
+                )),
+            ], {phenomenon}, list(expr.risks)
+        raise ValueError(phenomenon)

--- a/reasoning_core/resources/_imperative_mesopy_runtime.py
+++ b/reasoning_core/resources/_imperative_mesopy_runtime.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import ast
+import copy
+import sys
+import time
+from typing import Iterable
+
+from ._imperative_mesopy_types import (
+    CallOutcome, MinimalPair, MesopyGoal, MesopySample, OBSERVED_ERRORS,
+)
+
+
+class _RuntimeMixin:
+    def minimal_pair(self, sample: MesopySample, attempts: int = 24) -> MinimalPair:
+        tree = ast.parse(sample.code)
+        mutations = self._mutation_sites(tree)
+        self.rng.shuffle(mutations)
+        for path, mutation in mutations[:attempts]:
+            mutated = copy.deepcopy(tree)
+            description = self._apply_mutation(mutated, path, mutation)
+            if description is None:
+                continue
+            ast.fix_missing_locations(mutated)
+            code = ast.unparse(mutated) + "\n"
+            outcome = self._profile(code, sample.entrypoint, sample.args, self.config.max_profile_steps)
+            if sample.call.ok and outcome.ok and outcome.value != sample.call.value:
+                return MinimalPair(sample, code, sample.entrypoint, outcome, description)
+        raise RuntimeError("could not find output-changing minimal mutation")
+
+    def _probe_args(self, arity: int, count: int) -> list[tuple[int, ...]]:
+        if arity == 0:
+            return [()]
+        mag = self.config.magnitude
+        special = [0, 1, -1, 2, -2, mag, -mag, mag + 1, -(mag + 1)]
+        probes: list[tuple[int, ...]] = []
+        for i in range(min(count, len(special))):
+            xs = [self.rng.randint(-mag, mag) for _ in range(arity)]
+            xs[i % arity] = special[i]
+            probes.append(tuple(xs))
+        while len(probes) < count:
+            probes.append(tuple(self.rng.randint(-mag - 2, mag + 2) for _ in range(arity)))
+        return list(dict.fromkeys(probes))
+
+    def _select_outcomes(
+        self, goal: MesopyGoal, outcomes: list[CallOutcome]
+    ) -> tuple[CallOutcome, ...] | None:
+        oks = [x for x in outcomes if x.ok]
+        fails = [x for x in outcomes if not x.ok and x.error in OBSERVED_ERRORS]
+        if goal.error:
+            fails = [x for x in fails if x.error == goal.error]
+        if goal.paired_runnability:
+            if not oks or not fails:
+                return None
+            pair = [self.rng.choice(oks), self.rng.choice(fails)]
+            self.rng.shuffle(pair)
+            return tuple(pair)
+        if goal.runnable is True:
+            return (self.rng.choice(oks),) if oks else None
+        if goal.runnable is False:
+            return (self.rng.choice(fails),) if fails else None
+        if goal.error:
+            return (self.rng.choice(fails),) if fails else None
+        return (self.rng.choice(outcomes),) if outcomes else None
+
+    def _probe_metrics(
+        self,
+        code: str,
+        entrypoint: str,
+        selected: CallOutcome,
+        arity: int,
+    ) -> tuple[float, int]:
+        if arity == 0:
+            return 1.0, 1
+        base = list(selected.args)
+        probes = [tuple(base)]
+        for i in range(arity):
+            changed = base[:]
+            changed[i] += 1 if changed[i] != 0 else 2
+            probes.append(tuple(changed))
+        outcomes = self._execute_many(code, entrypoint, probes)
+        base_out = outcomes[0]
+        changed = sum(
+            (out.ok, out.value, out.error) != (base_out.ok, base_out.value, base_out.error)
+            for out in outcomes[1:]
+        )
+        diversity = len({(x.ok, x.value, x.error) for x in outcomes})
+        return changed / arity, diversity
+
+    @staticmethod
+    def _namespace():
+        return {
+            "__builtins__": {
+                "abs": abs,
+                "len": len,
+                "list": list,
+                "max": max,
+                "min": min,
+                "range": range,
+                "reversed": reversed,
+                "sorted": sorted,
+                "sum": sum,
+                "enumerate": enumerate,
+                "zip": zip,
+                "IndexError": IndexError,
+                "ZeroDivisionError": ZeroDivisionError,
+                "ValueError": ValueError,
+                "KeyError": KeyError,
+                "Exception": Exception,
+            }
+        }
+
+    def _execute_many(
+        self, code: str, entrypoint: str, args_list: Iterable[tuple[int, ...]]
+    ) -> list[CallOutcome]:
+        ns = self._namespace()
+        args_list = list(args_list)
+        try:
+            compiled = compile(code, "<imperative-mesopy>", "exec")
+            exec(compiled, ns, ns)
+            fn = ns[entrypoint]
+        except Exception as exc:
+            err = type(exc).__name__
+            return [CallOutcome(tuple(args), False, None, err) for args in args_list]
+        results = []
+        for args in args_list:
+            start = time.perf_counter()
+            try:
+                value = fn(*args)
+                results.append(CallOutcome(tuple(args), True, repr(value), None, time.perf_counter() - start))
+            except Exception as exc:
+                results.append(CallOutcome(tuple(args), False, None, type(exc).__name__, time.perf_counter() - start))
+        return results
+
+    def _profile(
+        self, code: str, entrypoint: str, args: tuple[int, ...], max_steps: int
+    ) -> CallOutcome:
+        ns = self._namespace()
+        filename = "<imperative-mesopy-profile>"
+        compiled = compile(code, filename, "exec")
+        exec(compiled, ns, ns)
+        fn = ns[entrypoint]
+        steps = 0
+        lines: set[int] = set()
+
+        class _StepLimit(Exception):
+            pass
+
+        def trace(frame, event, arg):
+            nonlocal steps
+            if event == "line" and frame.f_code.co_filename == filename:
+                steps += 1
+                lines.add(frame.f_lineno)
+                if steps > max_steps:
+                    raise _StepLimit
+            return trace
+
+        start = time.perf_counter()
+        old_trace = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            value = fn(*args)
+            return CallOutcome(args, True, repr(value), None, time.perf_counter() - start, steps, len(lines))
+        except _StepLimit:
+            return CallOutcome(args, False, None, "StepLimit", time.perf_counter() - start, steps, len(lines))
+        except Exception as exc:
+            return CallOutcome(args, False, None, type(exc).__name__, time.perf_counter() - start, steps, len(lines))
+        finally:
+            sys.settrace(old_trace)
+
+    @staticmethod
+    def _mutation_sites(tree: ast.AST):
+        sites = []
+        for idx, node in enumerate(ast.walk(tree)):
+            if isinstance(node, ast.Compare) and len(node.ops) == 1:
+                sites.append((idx, "compare"))
+            elif isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
+                sites.append((idx, "constant"))
+            elif isinstance(node, ast.AugAssign) and isinstance(node.op, (ast.Add, ast.Sub)):
+                sites.append((idx, "augop"))
+            elif isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub)):
+                sites.append((idx, "binop"))
+        return sites
+
+    def _apply_mutation(self, tree: ast.AST, path: int, mutation: str) -> str | None:
+        nodes = list(ast.walk(tree))
+        if path >= len(nodes):
+            return None
+        node = nodes[path]
+        if mutation == "compare" and isinstance(node, ast.Compare):
+            op = node.ops[0]
+            swaps = {
+                ast.Lt: ast.LtE,
+                ast.LtE: ast.Lt,
+                ast.Gt: ast.GtE,
+                ast.GtE: ast.Gt,
+                ast.Eq: ast.NotEq,
+                ast.NotEq: ast.Eq,
+            }
+            cls = swaps.get(type(op))
+            if cls:
+                node.ops[0] = cls()
+                return f"{type(op).__name__}->{cls.__name__}"
+        if mutation == "constant" and isinstance(node, ast.Constant) and isinstance(node.value, int):
+            delta = self.rng.choice((-1, 1))
+            old = node.value
+            node.value += delta
+            return f"constant {old}->{node.value}"
+        if mutation == "augop" and isinstance(node, ast.AugAssign):
+            old = type(node.op)
+            node.op = ast.Sub() if isinstance(node.op, ast.Add) else ast.Add()
+            return f"{old.__name__}->{type(node.op).__name__}"
+        if mutation == "binop" and isinstance(node, ast.BinOp):
+            old = type(node.op)
+            node.op = ast.Sub() if isinstance(node.op, ast.Add) else ast.Add()
+            return f"{old.__name__}->{type(node.op).__name__}"
+        return None

--- a/reasoning_core/resources/_imperative_mesopy_stmt.py
+++ b/reasoning_core/resources/_imperative_mesopy_stmt.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import ast
+from typing import Iterable
+
+from ._imperative_mesopy_types import INT, LIST_INT, OBSERVED_ERRORS, Risk, VarInfo, _Env, MesopyComplexity
+
+
+class _StatementMixin:
+    def _merge_existing(self, env: _Env, children: Iterable[_Env], names: Iterable[str]) -> None:
+        children = list(children)
+        for name in names:
+            infos = [child.vars.get(name) for child in children if name in child.vars]
+            if not infos:
+                continue
+            base = env.info(name)
+            deps = base.deps | frozenset().union(*(info.deps for info in infos))
+            depth = max([base.depth] + [info.depth for info in infos])
+            lengths = {info.length for info in infos if info.length is not None}
+            length = base.length if not lengths else (next(iter(lengths)) if len(lengths) == 1 else None)
+            env.vars[name] = VarInfo(base.typ, deps, depth, length)
+
+    def _gen_effect(
+        self,
+        env: _Env,
+        focus: str,
+        state: str,
+        control_depth: int,
+        expr_depth: int,
+        cx: MesopyComplexity,
+    ) -> tuple[list[ast.stmt], set[str], list[Risk]]:
+        kinds = ["focus", "mutate"]
+        if control_depth > 0:
+            kinds += ["if", "for", "while"]
+        kind = self.rng.choice(kinds)
+
+        if kind == "focus":
+            expr = self._gen_int_expr(env, max(0, expr_depth - 1))
+            old = env.info(focus)
+            env.vars[focus] = VarInfo(INT, old.deps | expr.deps, max(old.depth, expr.depth) + 1)
+            return [ast.AugAssign(
+                ast.Name(focus, ast.Store()),
+                self.rng.choice((ast.Add(), ast.Sub())),
+                expr.node,
+            )], set(), list(expr.risks)
+
+        if kind == "mutate":
+            info = env.info(state)
+            value = self._gen_int_expr(env, max(0, expr_depth - 1))
+            idx = self._gen_int_expr(env, max(0, expr_depth - 1))
+            idx_node = idx.node
+            risks = list(value.risks + idx.risks)
+            if not self._take_risk() and info.length:
+                idx_node = ast.BinOp(
+                    ast.Call(ast.Name("abs", ast.Load()), [idx.node], []),
+                    ast.Mod(),
+                    ast.Constant(info.length),
+                )
+            else:
+                risks.append(Risk("IndexError", idx.deps))
+            env.vars[state] = VarInfo(LIST_INT, info.deps | value.deps | idx.deps, info.depth + 1, info.length)
+            old = env.info(focus)
+            env.vars[focus] = VarInfo(INT, old.deps | env.info(state).deps, old.depth + 1)
+            return [
+                ast.AugAssign(
+                    ast.Subscript(ast.Name(state, ast.Load()), idx_node, ast.Store()),
+                    self.rng.choice((ast.Add(), ast.Sub())),
+                    value.node,
+                ),
+                ast.AugAssign(
+                    ast.Name(focus, ast.Store()), ast.Add(),
+                    ast.Call(ast.Name("len", ast.Load()), [ast.Name(state, ast.Load())], []),
+                ),
+            ], {"mutation_call"}, risks
+
+        if kind == "if":
+            cond = self._gen_bool_expr(env, max(0, expr_depth - 1))
+            yes_env, no_env = env.copy(), env.copy()
+            yes, yes_tags, yes_risks = self._gen_effect(
+                yes_env, focus, state, control_depth - 1, expr_depth, cx
+            )
+            no, no_tags, no_risks = self._gen_effect(
+                no_env, focus, state, control_depth - 1, expr_depth, cx
+            )
+            self._merge_existing(env, (yes_env, no_env), (focus, state))
+            return [ast.If(cond.node, yes, no)], {"conditional_flow"} | yes_tags | no_tags, list(cond.risks) + yes_risks + no_risks
+
+        if kind == "for":
+            child = env.copy()
+            inner, tags, risks = self._gen_effect(
+                child, focus, state, control_depth - 1, expr_depth, cx
+            )
+            self._merge_existing(env, (child,), (focus, state))
+            it = self.names.take("i")
+            bound = self.rng.randint(1, max(1, cx.loop_bound))
+            return [ast.For(
+                ast.Name(it, ast.Store()),
+                ast.Call(ast.Name("range", ast.Load()), [ast.Constant(bound)], []),
+                inner,
+                [],
+            )], {"loop_carried_state"} | tags, risks
+
+        child = env.copy()
+        inner, tags, risks = self._gen_effect(
+            child, focus, state, control_depth - 1, expr_depth, cx
+        )
+        self._merge_existing(env, (child,), (focus, state))
+        counter = self.names.take("i")
+        limit = self.rng.randint(1, max(1, cx.loop_bound))
+        return [
+            ast.Assign([ast.Name(counter, ast.Store())], ast.Constant(0)),
+            ast.While(
+                ast.Compare(ast.Name(counter, ast.Load()), [ast.Lt()], [ast.Constant(limit)]),
+                inner + [ast.AugAssign(ast.Name(counter, ast.Store()), ast.Add(), ast.Constant(1))],
+                [],
+            ),
+        ], {"loop_carried_state"} | tags, risks
+
+    def _gen_stmt(
+        self,
+        env: _Env,
+        focus: str,
+        state: str,
+        control_depth: int,
+        expr_depth: int,
+        cx: MesopyComplexity,
+    ) -> tuple[list[ast.stmt], set[str], list[Risk]]:
+        kinds = ["focus", "mutate", "assign", "dict", "swap", "comprehension"]
+        if control_depth > 0:
+            kinds += ["if", "for", "while", "try"]
+        kind = self.rng.choice(kinds)
+        tags: set[str] = set()
+        risks: list[Risk] = []
+
+        if kind == "focus":
+            expr = self._gen_int_expr(env, expr_depth, required=set(env.params) if self.rng.random() < 0.35 else None)
+            op = self.rng.choice((ast.Add(), ast.Sub()))
+            node = ast.AugAssign(ast.Name(focus, ast.Store()), op, expr.node)
+            old = env.info(focus)
+            env.add(focus, VarInfo(INT, old.deps | expr.deps, max(old.depth, expr.depth) + 1))
+            return [node], tags, list(expr.risks)
+
+        if kind == "mutate":
+            list_name = self.rng.choice(env.names(LIST_INT))
+            info = env.info(list_name)
+            value = self._gen_int_expr(env, max(0, expr_depth - 1))
+            if self.rng.random() < 0.45:
+                node = ast.Expr(ast.Call(ast.Attribute(ast.Name(list_name, ast.Load()), "append", ast.Load()), [value.node], []))
+                env.vars[list_name] = VarInfo(LIST_INT, info.deps | value.deps, info.depth + 1, None if info.length is None else info.length + 1)
+            else:
+                idx = self._gen_int_expr(env, max(0, expr_depth - 1))
+                idx_node = idx.node
+                node_risks = list(value.risks + idx.risks)
+                if not self._take_risk() and info.length:
+                    idx_node = ast.BinOp(ast.Call(ast.Name("abs", ast.Load()), [idx.node], []), ast.Mod(), ast.Constant(info.length))
+                else:
+                    node_risks.append(Risk("IndexError", idx.deps))
+                node = ast.AugAssign(
+                    ast.Subscript(ast.Name(list_name, ast.Load()), idx_node, ast.Store()),
+                    self.rng.choice((ast.Add(), ast.Sub())),
+                    value.node,
+                )
+                env.vars[list_name] = VarInfo(LIST_INT, info.deps | value.deps | idx.deps, info.depth + 1, info.length)
+                risks.extend(node_risks)
+            use = ast.AugAssign(
+                ast.Name(focus, ast.Store()),
+                ast.Add(),
+                ast.Call(ast.Name("len", ast.Load()), [ast.Name(list_name, ast.Load())], []),
+            )
+            old = env.info(focus)
+            env.add(focus, VarInfo(INT, old.deps | env.info(list_name).deps, old.depth + 1))
+            return [node, use], {"mutation_call"}, risks + list(value.risks)
+
+        if kind == "assign":
+            expr = self._gen_int_expr(env, expr_depth)
+            name = self.names.take("v")
+            env.add(name, expr)
+            nodes = [ast.Assign([ast.Name(name, ast.Store())], expr.node)]
+            if self.rng.random() > self.config.noise_rate:
+                nodes.append(ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Name(name, ast.Load())))
+                old = env.info(focus)
+                env.add(focus, VarInfo(INT, old.deps | expr.deps, max(old.depth, expr.depth) + 1))
+            return nodes, tags, list(expr.risks)
+
+        if kind == "dict":
+            expr = self._gen_dict_expr(env, expr_depth)
+            name = self.names.take("map")
+            env.add(name, expr)
+            key = self._gen_int_expr(env, max(0, expr_depth - 1))
+            if not self._take_risk():
+                access = ast.Call(ast.Attribute(ast.Name(name, ast.Load()), "get", ast.Load()), [key.node, ast.Constant(0)], [])
+                access_risks = key.risks
+            else:
+                access = ast.Subscript(ast.Name(name, ast.Load()), key.node, ast.Load())
+                access_risks = key.risks + (Risk("KeyError", key.deps),)
+            nodes = [
+                ast.Assign([ast.Name(name, ast.Store())], expr.node),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), access),
+            ]
+            old = env.info(focus)
+            env.add(focus, VarInfo(INT, old.deps | expr.deps | key.deps, max(old.depth, expr.depth, key.depth) + 1))
+            return nodes, {"mapping"}, list(expr.risks + access_risks)
+
+        if kind == "swap":
+            other = self.names.take("v")
+            expr = self._gen_int_expr(env, max(0, expr_depth - 1))
+            env.add(other, expr)
+            nodes = [
+                ast.Assign([ast.Name(other, ast.Store())], expr.node),
+                ast.Assign(
+                    [ast.Tuple([ast.Name(focus, ast.Store()), ast.Name(other, ast.Store())], ast.Store())],
+                    ast.Tuple([ast.Name(other, ast.Load()), ast.Name(focus, ast.Load())], ast.Load()),
+                ),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Name(other, ast.Load())),
+            ]
+            old = env.info(focus)
+            env.add(focus, VarInfo(INT, old.deps | expr.deps, max(old.depth, expr.depth) + 2))
+            return nodes, tags, list(expr.risks)
+
+        if kind == "comprehension":
+            it = self.names.take("i")
+            name = self.names.take("comp")
+            bound = self.rng.randint(2, max(2, cx.loop_bound))
+            expr = self._gen_int_expr(env, max(0, expr_depth - 1))
+            comp = ast.ListComp(
+                ast.BinOp(ast.Name(it, ast.Load()), ast.Add(), expr.node),
+                [ast.comprehension(ast.Name(it, ast.Store()), ast.Call(ast.Name("range", ast.Load()), [ast.Constant(bound)], []), [], 0)],
+            )
+            env.add(name, VarInfo(LIST_INT, expr.deps, expr.depth + 1, bound))
+            nodes = [
+                ast.Assign([ast.Name(name, ast.Store())], comp),
+                ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), ast.Call(ast.Name("sum", ast.Load()), [ast.Name(name, ast.Load())], [])),
+            ]
+            old = env.info(focus)
+            env.add(focus, VarInfo(INT, old.deps | expr.deps, max(old.depth, expr.depth) + 2))
+            return nodes, {"comprehension"}, list(expr.risks)
+
+        if kind in {"if", "for", "while"}:
+            nodes, nested_tags, nested_risks = self._gen_effect(
+                env, focus, state, max(0, control_depth - 1), expr_depth, cx
+            )
+            if kind == "if" and not isinstance(nodes[0], ast.If):
+                cond = self._gen_bool_expr(env, max(0, expr_depth - 1))
+                yes_env, no_env = env.copy(), env.copy()
+                yes, yes_tags, yes_risks = self._gen_effect(yes_env, focus, state, max(0, control_depth - 1), expr_depth, cx)
+                no, no_tags, no_risks = self._gen_effect(no_env, focus, state, max(0, control_depth - 1), expr_depth, cx)
+                self._merge_existing(env, (yes_env, no_env), (focus, state))
+                return [ast.If(cond.node, yes, no)], {"conditional_flow"} | yes_tags | no_tags, list(cond.risks) + yes_risks + no_risks
+            if kind == "for" and not isinstance(nodes[0], ast.For):
+                child = env.copy()
+                inner, inner_tags, inner_risks = self._gen_effect(child, focus, state, max(0, control_depth - 1), expr_depth, cx)
+                self._merge_existing(env, (child,), (focus, state))
+                it = self.names.take("i")
+                bound = self.rng.randint(1, max(1, cx.loop_bound))
+                return [ast.For(ast.Name(it, ast.Store()), ast.Call(ast.Name("range", ast.Load()), [ast.Constant(bound)], []), inner, [])], {"loop_carried_state"} | inner_tags, inner_risks
+            if kind == "while" and not isinstance(nodes[0], ast.While):
+                child = env.copy()
+                inner, inner_tags, inner_risks = self._gen_effect(child, focus, state, max(0, control_depth - 1), expr_depth, cx)
+                self._merge_existing(env, (child,), (focus, state))
+                counter = self.names.take("i")
+                limit = self.rng.randint(1, max(1, cx.loop_bound))
+                return [
+                    ast.Assign([ast.Name(counter, ast.Store())], ast.Constant(0)),
+                    ast.While(
+                        ast.Compare(ast.Name(counter, ast.Load()), [ast.Lt()], [ast.Constant(limit)]),
+                        inner + [ast.AugAssign(ast.Name(counter, ast.Store()), ast.Add(), ast.Constant(1))],
+                        [],
+                    ),
+                ], {"loop_carried_state"} | inner_tags, inner_risks
+            return nodes, nested_tags, nested_risks
+
+        risky = self._force_risky_int_expr(env, max(1, expr_depth - 1))
+        fallback = self._gen_int_expr(env, max(0, expr_depth - 1))
+        exc = self.rng.choice(tuple({r.kind for r in risky.risks}) or OBSERVED_ERRORS)
+        node = ast.Try(
+            [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Add(), risky.node)],
+            [ast.ExceptHandler(ast.Name(exc, ast.Load()), None, [ast.AugAssign(ast.Name(focus, ast.Store()), ast.Sub(), fallback.node)])],
+            [],
+            [],
+        )
+        old = env.info(focus)
+        env.add(focus, VarInfo(INT, old.deps | risky.deps | fallback.deps, max(old.depth, risky.depth, fallback.depth) + 1))
+        return [node], {"try_except"}, list(risky.risks + fallback.risks)

--- a/reasoning_core/resources/_imperative_mesopy_types.py
+++ b/reasoning_core/resources/_imperative_mesopy_types.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Iterable
+
+INT = "int"
+BOOL = "bool"
+LIST_INT = "list[int]"
+DICT_INT = "dict[int,int]"
+TUPLE_INT = "tuple[int,int]"
+
+OBSERVED_ERRORS = ("IndexError", "ZeroDivisionError", "ValueError", "KeyError")
+CONTROLLED_PHENOMENA = (
+    "aliasing",
+    "closure_late_binding",
+    "default_capture",
+    "mutation_call",
+    "loop_carried_state",
+    "rebinding_vs_aliasing",
+)
+PHENOMENA = CONTROLLED_PHENOMENA + (
+    "mutable_default",
+    "conditional_flow",
+    "try_except",
+    "early_return",
+    "comprehension",
+    "mapping",
+    "recursion",
+)
+
+_REALISTIC_NAMES = (
+    "total", "idx", "buf", "scale", "offset", "rows", "acc", "tmp", "n", "k",
+    "value", "values", "items", "data", "count", "step", "delta", "result", "out",
+    "left", "right", "current", "next_value", "limit", "pos", "key", "table", "seq",
+    "work", "score", "base", "factor", "part", "cache", "state", "nums", "target",
+)
+
+@dataclass(frozen=True)
+class MesopyComplexity:
+    statements: int = 10
+    expr_depth: int = 3
+    control_depth: int = 2
+    functions: int = 2
+    call_depth: int = 2
+    dataflow_depth: int = 5
+    loop_bound: int = 4
+
+    @classmethod
+    def level(cls, level: int) -> "MesopyComplexity":
+        level = max(0, int(level))
+        return cls(
+            statements=7 + 3 * level,
+            expr_depth=2 + level // 2,
+            control_depth=1 + level // 2,
+            functions=1 + level // 2,
+            call_depth=1 + level // 2,
+            dataflow_depth=3 + level,
+            loop_bound=3 + level // 2,
+        )
+
+@dataclass(frozen=True)
+class MesopyGoal:
+    runnable: bool | None = True
+    paired_runnability: bool = False
+    error: str | None = None
+    result_kind: str | None = None
+    input_arity: int | None = None
+    phenomena: tuple[str, ...] = ()
+    complexity: MesopyComplexity | None = None
+    allow_recursion: bool = True
+    require_recursion: bool = False
+    min_live_fraction: float = 0.35
+    min_param_sensitivity: float = 0.0
+    anonymize_names: bool | None = None
+
+@dataclass
+class MesopyConfig:
+    magnitude: int = 7
+    list_size: tuple[int, int] = (3, 7)
+    input_arity: tuple[int, int] = (1, 3)
+    complexity: MesopyComplexity = field(default_factory=MesopyComplexity)
+    probe_count: int = 16
+    risk_rate: float = 0.35
+    max_risk_sites: int = 2
+    phenomenon_rate: float = 0.22
+    noise_rate: float = 0.12
+    recursion_rate: float = 0.24
+    anonymize_names: bool = False
+    deduplicate: bool = False
+    max_attempts: int = 28
+    profile_accepted: bool = True
+    max_profile_steps: int = 100_000
+
+@dataclass(frozen=True)
+class Risk:
+    kind: str
+    deps: frozenset[str]
+
+@dataclass(frozen=True)
+class ExprSpec:
+    node: ast.expr
+    typ: str
+    deps: frozenset[str] = frozenset()
+    risks: tuple[Risk, ...] = ()
+    depth: int = 1
+
+@dataclass
+class VarInfo:
+    typ: str
+    deps: frozenset[str]
+    depth: int = 1
+    length: int | None = None
+
+@dataclass(frozen=True)
+class CallOutcome:
+    args: tuple[int, ...]
+    ok: bool
+    value: str | None = None
+    error: str | None = None
+    elapsed: float | None = None
+    steps: int | None = None
+    distinct_lines: int | None = None
+
+@dataclass
+class MesopySample:
+    code: str
+    entrypoint: str
+    calls: tuple[CallOutcome, ...]
+    phenomena: tuple[str, ...]
+    features: dict
+    fingerprint: str
+
+    @property
+    def call(self) -> CallOutcome:
+        return self.calls[0]
+
+    @property
+    def args(self) -> tuple[int, ...]:
+        return self.call.args
+
+    @property
+    def answer(self) -> str | None:
+        return self.call.value if self.call.ok else self.call.error
+
+@dataclass(frozen=True)
+class MinimalPair:
+    original: MesopySample
+    code: str
+    entrypoint: str
+    outcome: CallOutcome
+    mutation: str
+
+class _Names:
+    def __init__(self):
+        self.n = 0
+
+    def take(self, prefix: str = "v") -> str:
+        self.n += 1
+        return f"{prefix}{self.n}"
+
+class _Env:
+    def __init__(self, params: Iterable[str] = ()):
+        self.vars: dict[str, VarInfo] = {}
+        self.params = tuple(params)
+        self.functions: list[str] = []
+        for p in self.params:
+            self.vars[p] = VarInfo(INT, frozenset({p}), 0)
+
+    def copy(self) -> "_Env":
+        other = _Env()
+        other.vars = dict(self.vars)
+        other.params = self.params
+        other.functions = self.functions[:]
+        return other
+
+    def add(self, name: str, spec: ExprSpec | VarInfo) -> None:
+        if isinstance(spec, ExprSpec):
+            self.vars[name] = VarInfo(spec.typ, spec.deps, spec.depth)
+        else:
+            self.vars[name] = spec
+
+    def names(self, typ: str | None = None) -> list[str]:
+        if typ is None:
+            return list(self.vars)
+        return [name for name, info in self.vars.items() if info.typ == typ]
+
+    def info(self, name: str) -> VarInfo:
+        return self.vars[name]

--- a/reasoning_core/resources/imperative_mesopy.py
+++ b/reasoning_core/resources/imperative_mesopy.py
@@ -1,0 +1,32 @@
+"""Goal-directed, recursively productive Python synthesis for code reasoning.
+
+V3 separates program generation from task labels. Risky operations are ordinary
+constructors; runnability is observed by executing one program on sampled inputs.
+Difficulty combines static slicing with a traced accepted call. Alpha-renaming is
+an optional final pass.
+"""
+
+from ._imperative_mesopy_analysis import structural_fingerprint
+from ._imperative_mesopy_expr import _ExpressionMixin
+from ._imperative_mesopy_generation import _GenerationMixin
+from ._imperative_mesopy_phenomena import _PhenomenaMixin
+from ._imperative_mesopy_runtime import _RuntimeMixin
+from ._imperative_mesopy_stmt import _StatementMixin
+from ._imperative_mesopy_types import (
+    BOOL, CONTROLLED_PHENOMENA, DICT_INT, INT, LIST_INT, OBSERVED_ERRORS, PHENOMENA,
+    TUPLE_INT, CallOutcome, MesopyComplexity, MesopyConfig, MesopyGoal, MesopySample, MinimalPair,
+)
+
+
+class ImperativeMesopy(
+    _GenerationMixin, _ExpressionMixin, _StatementMixin, _PhenomenaMixin, _RuntimeMixin
+):
+    pass
+
+
+__all__ = [
+    "BOOL", "CONTROLLED_PHENOMENA", "DICT_INT", "INT", "LIST_INT",
+    "OBSERVED_ERRORS", "PHENOMENA", "TUPLE_INT", "CallOutcome",
+    "ImperativeMesopy", "MesopyComplexity", "MesopyConfig", "MesopyGoal",
+    "MesopySample", "MinimalPair", "structural_fingerprint",
+]

--- a/tests/test_imperative_mesopy.py
+++ b/tests/test_imperative_mesopy.py
@@ -1,0 +1,158 @@
+import ast
+import statistics
+import time
+
+import pytest
+
+from reasoning_core.resources.imperative_mesopy import (
+    CONTROLLED_PHENOMENA,
+    OBSERVED_ERRORS,
+    PHENOMENA,
+    ImperativeMesopy,
+    MesopyComplexity,
+    MesopyConfig,
+    structural_fingerprint,
+)
+
+
+def test_execution_is_runnable_and_measured():
+    for seed in range(100):
+        sample = ImperativeMesopy(seed=seed).execution()
+        assert sample.call.ok, (seed, sample.call.error, sample.code)
+        assert sample.features["dynamic_steps"] > 0
+        assert sample.features["dynamic_lines"] > 0
+        assert sample.features["live_fraction"] >= 0.35
+        assert sample.features["backward_slice_depth"] > 0
+        assert sample.features["param_sensitivity"] >= 0
+
+
+def test_runnability_is_observed_from_same_program_distribution():
+    differing_positions = set()
+    errors = set()
+    for seed in range(80):
+        sample = ImperativeMesopy(seed=seed).runnability_pair()
+        assert {call.ok for call in sample.calls} == {True, False}
+        assert "haz" not in {n.id for n in ast.walk(ast.parse(sample.code)) if isinstance(n, ast.Name)}
+        a, b = sample.calls
+        differing_positions.update(i for i, pair in enumerate(zip(a.args, b.args)) if pair[0] != pair[1])
+        errors.update(call.error for call in sample.calls if call.error)
+    assert len(differing_positions) >= 2
+    assert len(errors & set(OBSERVED_ERRORS)) >= 3
+
+
+def test_optional_alpha_renaming_preserves_semantics_and_fingerprint():
+    for seed in range(30):
+        plain = ImperativeMesopy(seed=seed).execution(anonymize_names=False)
+        anonymous = ImperativeMesopy(seed=seed).execution(anonymize_names=True)
+        assert plain.args == anonymous.args
+        assert (plain.call.ok, plain.call.value, plain.call.error) == (
+            anonymous.call.ok,
+            anonymous.call.value,
+            anonymous.call.error,
+        )
+        assert plain.entrypoint == "endpoint"
+        assert anonymous.entrypoint != "endpoint"
+        assert plain.fingerprint == anonymous.fingerprint
+        assert structural_fingerprint(plain.code) == structural_fingerprint(anonymous.code)
+
+
+def test_complexity_is_recursively_productive_and_measured():
+    medians = []
+    for level in (0, 3, 6):
+        samples = [
+            ImperativeMesopy(
+                MesopyConfig(complexity=MesopyComplexity.level(level)), seed=seed
+            ).execution()
+            for seed in range(12)
+        ]
+        medians.append({
+            key: statistics.median(sample.features[key] for sample in samples)
+            for key in (
+                "ast_nodes",
+                "ast_depth",
+                "control_depth",
+                "call_depth",
+                "backward_slice_depth",
+                "dynamic_steps",
+            )
+        })
+
+    assert medians[0]["ast_nodes"] < medians[1]["ast_nodes"] < medians[2]["ast_nodes"]
+    assert medians[0]["ast_depth"] < medians[2]["ast_depth"]
+    assert medians[0]["control_depth"] < medians[2]["control_depth"]
+    assert medians[0]["call_depth"] < medians[2]["call_depth"]
+    assert medians[0]["backward_slice_depth"] < medians[2]["backward_slice_depth"]
+    assert medians[0]["dynamic_steps"] < medians[1]["dynamic_steps"] < medians[2]["dynamic_steps"]
+
+
+def test_controlled_phenomena_are_a_subset_not_the_program_skeleton():
+    assert set(CONTROLLED_PHENOMENA) < set(PHENOMENA)
+    for phenomenon in PHENOMENA:
+        for seed in range(20):
+            try:
+                sample = ImperativeMesopy(seed=seed).execution(
+                    phenomena=(phenomenon,),
+                    require_recursion=phenomenon == "recursion",
+                )
+                break
+            except RuntimeError:
+                continue
+        else:
+            pytest.fail(f"could not generate requested phenomenon {phenomenon}")
+        assert sample.call.ok
+        assert phenomenon in sample.phenomena
+
+
+def test_recursion_is_real_and_terminating():
+    sample = ImperativeMesopy(seed=4).execution(require_recursion=True)
+    tree = ast.parse(sample.code)
+    recursive = []
+    for fn in (n for n in tree.body if isinstance(n, ast.FunctionDef)):
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == fn.name
+            for node in ast.walk(fn)
+        ):
+            recursive.append(fn)
+    assert recursive
+    assert sample.call.ok
+
+
+def test_minimal_pair_uses_step_limited_validation():
+    successes = 0
+    for seed in range(12):
+        sample = ImperativeMesopy(seed=seed).execution()
+        try:
+            pair = ImperativeMesopy(seed=1000 + seed).minimal_pair(sample, attempts=32)
+        except RuntimeError:
+            continue
+        assert pair.outcome.ok
+        assert pair.outcome.value != sample.call.value
+        assert pair.outcome.steps is not None
+        successes += 1
+    assert successes >= 8
+
+
+def test_generation_throughput_stays_fast():
+    t0 = time.perf_counter()
+    for seed in range(100):
+        assert ImperativeMesopy(seed=seed).execution().call.ok
+    execution_seconds = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for seed in range(50):
+        sample = ImperativeMesopy(seed=seed).runnability_pair()
+        assert {call.ok for call in sample.calls} == {True, False}
+    runnability_seconds = time.perf_counter() - t0
+
+    cfg = MesopyConfig(complexity=MesopyComplexity.level(6))
+    t0 = time.perf_counter()
+    for seed in range(8):
+        assert ImperativeMesopy(cfg, seed=seed).execution().call.ok
+    high_complexity_seconds = time.perf_counter() - t0
+
+    # Wide CI margins. These are regression tripwires, not benchmark claims.
+    assert execution_seconds < 5.0
+    assert runnability_seconds < 5.0
+    assert high_complexity_seconds < 5.0


### PR DESCRIPTION
V3 is a fresh implementation from `main`, replacing the design direction of #50 rather than incrementally patching it.

## Core design

- Recursively productive typed-ish AST synthesis over int/bool/list[int]/dict[int,int] with tuple/list/int outputs.
- Recursive expression and control-flow generation under explicit complexity budgets.
- Live control-flow effects: generated branch/loop bodies mutate existing semantic state, and child environments are merged back only for variables that are valid after the block.
- Dependency sets are tracked through expressions and state. Returns are constructed to depend on all endpoint parameters.
- Actual terminating generated recursion uses a decreasing rank.
- Controlled-code-execution phenomena remain requestable, but are not the program skeleton. V3 also supports mutable defaults, try/except, early return, comprehensions, mappings, and recursion.

## Runnability

Runnability is observed, not planted:

1. risky operations are ordinary expression/statement constructors;
2. each generated program is executed over a probe set;
3. successful and naturally failing calls are partitioned by observed outcome;
4. a runnability pair samples one from each partition while keeping identical source.

There is no designated hazard statement, no fixed final failure site, and no safe/bad argument constructor. Unguarded risk is controlled by a small program-level risk-site budget so increasing program complexity does not make every probe crash.

Observed failure families are `IndexError`, `ZeroDivisionError`, `ValueError`, and `KeyError`. Caught hazards may also appear in otherwise runnable code.

## Leakage / measurement

- Alpha-renaming is an **optional** final pass (`anonymize_names`), not mandatory. It renames bound names and the entrypoint using a realistic name pool, then re-executes to verify semantic preservation.
- Helper/endpoint definition order is shuffled.
- Structural fingerprints alpha-normalize names and abstract literals for deduplication / collision monitoring.
- Static liveness and backward-slice metrics are computed for every candidate; low-live-fraction candidates can be rejected.
- Accepted calls are traced for dynamic steps/distinct executed lines. Rejected probes are not traced, preserving generation speed.
- Parameter sensitivity and probe-output diversity are measured from executions.
- Minimal-pair AST mutations are validated under a step limit, since mutations can destroy a generated loop invariant even when normal generation is bounded.

## Complexity

`MesopyComplexity` controls statements, expression depth, control depth, function count, call depth, dataflow depth, and loop bounds. Tests compare levels 0, 3, and 6 and require increasing structural and measured dynamic difficulty, rather than trusting configuration alone.

## Performance / stress on the exact split implementation

- 1,000 executable samples: 0 generation failures, 11.52 s, **86.8 programs/s**
- 500 runnability pairs: 0 generation failures, 6.60 s, **75.7 pairs/s**
- 50 complexity-level-6 executable samples: 0 failures, 2.54 s, **19.7 programs/s**
- observed failures across the 500 pairs: 284 ZeroDivisionError, 113 IndexError, 93 ValueError, 10 KeyError
- pair argument differences covered parameter positions 0, 1, and 2
- targeted local suite: **8 passed**

CI throughput assertions intentionally use wide margins (100 execution <5 s, 50 pairs <5 s, 8 level-6 execution <5 s) as regression tripwires rather than machine-specific benchmarks.

## Deliberately not included

I did not take every review suggestion mechanically. This PR does not add formatting/comment jitter, Hypothesis, RestrictedPython, subprocess execution for the trusted bounded generator path, classes/imports/floats/mutual recursion, or mined-real-code mixing. Those either improve cosmetic realism more than reasoning diversity, add dependencies/complexity without fixing the main shortcut risks, or belong in a later distribution-expansion layer.

This PR only adds the reusable V3 resource and its tests. Task migrations can be evaluated separately against one common generator distribution.